### PR TITLE
Include API version in model endpoints

### DIFF
--- a/examples/api_logging.py
+++ b/examples/api_logging.py
@@ -24,12 +24,12 @@ class Model(BaseModel):
 prediction_svc = PredictionService(
     model=Model(),
     name='my-model',
-    version='1',
+    api_version='1',
     batch_prediction=False,
     log_api_calls=True)
 middleware_svc = MiddlewareService(
     name='my-model',
-    version='1',
+    api_version='1',
     max_workers=None,  # use default
     model_endpoint=f'http://localhost:5000{prediction_svc.endpoint}')
 app.add_services(prediction_svc, middleware_svc)

--- a/examples/example.py
+++ b/examples/example.py
@@ -11,7 +11,7 @@ such as
 
 to the endpoint
 
-    <host>:<port>/supa-dupa-model/prediction/
+    <host>:<port>/supa-dupa-model/v1/prediction/
 
 The corresponding output has the format
 
@@ -77,7 +77,7 @@ service_config = PredictionService(
                                     #   host:port/supa-dupa-model/prediction/
                                     # Required.
                                     #
-    version='1.0.0',                # The version of the model. Returned
+    version='v1',                   # The version of the model. Returned
                                     # to client in the prediction response.
                                     # Required.
                                     #

--- a/examples/example.py
+++ b/examples/example.py
@@ -77,7 +77,7 @@ service_config = PredictionService(
                                     #   host:port/supa-dupa-model/prediction/
                                     # Required.
                                     #
-    version='v1',                   # The version of the model. Returned
+    api_version='v1',               # The version of the model. Returned
                                     # to client in the prediction response.
                                     # Required.
                                     #

--- a/examples/health_check_endpoints.py
+++ b/examples/health_check_endpoints.py
@@ -11,19 +11,19 @@ from porter.services import ModelApp, PredictionService
 service_config_1 = PredictionService(
     model=None,
     name='a-model',
-    version='0.0.0'
+    api_version='0.0.0'
 )
 
 service_config_2 = PredictionService(
     model=None,
     name='yet-another-model',
-    version='1.0.0'
+    api_version='1.0.0'
 )
 
 service_config_3 = PredictionService(
     model=None,
     name='yet-another-yet-another-model',
-    version='1.0.0-alpha',
+    api_version='1.0.0-alpha',
     meta={'arbitrary details': 'about the model'}
 )
 

--- a/examples/middleware.py
+++ b/examples/middleware.py
@@ -22,16 +22,16 @@ class Model(BaseModel):
 prediction_svc = PredictionService(
     model=Model(),
     name='my-model',
-    version='1',
+    api_version='1',
     batch_prediction=False)
 middleware_svc = MiddlewareService(
     name='my-model',
-    version='1',
+    api_version='1',
     max_workers=None,  # use default
     model_endpoint=f'http://localhost:5000{prediction_svc.endpoint}')
 middleware_svc_never_ready = MiddlewareService(
     name='another-model',
-    version='1',
+    api_version='1',
     max_workers=None,  # use default
     model_endpoint=f'http://localhost:8000/does-not-exist')
 app.add_services(prediction_svc, middleware_svc, middleware_svc_never_ready)

--- a/porter/constants.py
+++ b/porter/constants.py
@@ -23,7 +23,7 @@ class ERRORS:
 class PREDICTION:
     """Container prediction endpoint constants."""
 
-    ENDPOINT_TEMPLATE = '/{model_name}/{model_version}/prediction'
+    ENDPOINT_TEMPLATE = '/{model_name}/{api_version}/prediction'
 
     class RESPONSE:
         class KEYS:
@@ -31,13 +31,13 @@ class PREDICTION:
 
             Attributes:
                 MODEL_NAME: Model name.
-                MODEL_VERSION: Model version.
+                API_VERSION: API version.
                 PREDICTIONS: Array of predictions key.
                 ID: Unique record ID key.
                 PREDICTION: Prediction for a given ID key.
             """
             MODEL_NAME = 'model_name'
-            MODEL_VERSION = 'model_version'
+            API_VERSION = 'api_version'
             ID = 'id'
             PREDICTIONS = 'predictions'
             PREDICTION = 'prediction'
@@ -47,7 +47,7 @@ class PREDICTION:
 class BATCH_PREDICTION:
     """Container prediction endpoint constants."""
 
-    ENDPOINT_TEMPLATE = '/{model_name}/{model_version}/batchPrediction'
+    ENDPOINT_TEMPLATE = '/{model_name}/{api_version}/batchPrediction'
     class RESPONSE:
         class KEYS:
             # meta key
@@ -71,7 +71,7 @@ class HEALTH_CHECK:
             STATUS = 'status'
             ENDPOINT = 'endpoint'
             NAME = 'name'
-            MODEL_VERSION = 'version'
+            API_VERSION = 'api_version'
             META = 'meta'
             PORTER_VERSION = 'porter_version'
             DEPLOYED_ON = 'deployed_on'

--- a/porter/constants.py
+++ b/porter/constants.py
@@ -23,7 +23,7 @@ class ERRORS:
 class PREDICTION:
     """Container prediction endpoint constants."""
 
-    ENDPOINT_TEMPLATE = '/{model_name}/prediction'
+    ENDPOINT_TEMPLATE = '/{model_name}/{model_version}/prediction'
 
     class RESPONSE:
         class KEYS:
@@ -47,7 +47,7 @@ class PREDICTION:
 class BATCH_PREDICTION:
     """Container prediction endpoint constants."""
 
-    ENDPOINT_TEMPLATE = '/{model_name}/batchPrediction'
+    ENDPOINT_TEMPLATE = '/{model_name}/{model_version}/batchPrediction'
     class RESPONSE:
         class KEYS:
             # meta key

--- a/porter/exceptions.py
+++ b/porter/exceptions.py
@@ -8,15 +8,15 @@ class ModelContextError(PorterError):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.model_name = None
-        self.model_version = None
+        self.api_version = None
         self.model_meta = None
 
     # users are not meant to call this - method simply exists to put the
     # responsibility on porter to properly set these values which pass
     # through to error responses
-    def update_model_context(self, model_name, model_version, model_meta):
+    def update_model_context(self, model_name, api_version, model_meta):
         self.model_name = model_name
-        self.model_version = model_version
+        self.api_version = api_version
         self.model_meta = model_meta
 
 

--- a/porter/responses.py
+++ b/porter/responses.py
@@ -1,7 +1,5 @@
 import traceback
 
-import flask
-
 from . import api
 from . import constants as cn
 from . import exceptions as exc

--- a/porter/responses.py
+++ b/porter/responses.py
@@ -4,8 +4,11 @@ from . import api
 from . import constants as cn
 from . import exceptions as exc
 
-# alias for convenience
+# aliases for convenience
 _IS_READY = cn.HEALTH_CHECK.RESPONSE.VALUES.STATUS_IS_READY
+_PREDICTION_KEYS = cn.PREDICTION.RESPONSE.KEYS
+_ERROR_KEYS = cn.ERRORS.RESPONSE.KEYS
+_HEALTH_CHECK_KEYS = cn.HEALTH_CHECK.RESPONSE.KEYS
 
 
 # NOTE: private functions make testing easier as they bypass `flask` methods
@@ -25,12 +28,12 @@ def make_prediction_response(model_name, model_version, model_meta, id_keys,
 
 def _make_batch_prediction_payload(model_name, model_version, model_meta, id_keys, predictions):
     payload = {
-        cn.PREDICTION.RESPONSE.KEYS.MODEL_NAME: model_name,
-        cn.PREDICTION.RESPONSE.KEYS.MODEL_VERSION: model_version,
-        cn.PREDICTION.RESPONSE.KEYS.PREDICTIONS: [
+        _PREDICTION_KEYS.MODEL_NAME: model_name,
+        _PREDICTION_KEYS.MODEL_VERSION: model_version,
+        _PREDICTION_KEYS.PREDICTIONS: [
             {
-                cn.PREDICTION.RESPONSE.KEYS.ID: id,
-                cn.PREDICTION.RESPONSE.KEYS.PREDICTION: p
+                _PREDICTION_KEYS.ID: id,
+                _PREDICTION_KEYS.PREDICTION: p
             }
             for id, p in zip(id_keys, predictions)]
     }
@@ -40,12 +43,12 @@ def _make_batch_prediction_payload(model_name, model_version, model_meta, id_key
 
 def _make_single_prediction_payload(model_name, model_version, model_meta, id_keys, predictions):
     payload = {
-        cn.PREDICTION.RESPONSE.KEYS.MODEL_NAME: model_name,
-        cn.PREDICTION.RESPONSE.KEYS.MODEL_VERSION: model_version,
-        cn.PREDICTION.RESPONSE.KEYS.PREDICTIONS:
+        _PREDICTION_KEYS.MODEL_NAME: model_name,
+        _PREDICTION_KEYS.MODEL_VERSION: model_version,
+        _PREDICTION_KEYS.PREDICTIONS:
             {
-                cn.PREDICTION.RESPONSE.KEYS.ID: id_keys[0],
-                cn.PREDICTION.RESPONSE.KEYS.PREDICTION: predictions[0]
+                _PREDICTION_KEYS.ID: id_keys[0],
+                _PREDICTION_KEYS.PREDICTION: predictions[0]
             }
     }
     payload.update(model_meta)
@@ -72,18 +75,18 @@ def _make_error_payload(error, user_data):
     # message - note that isinstance(obj, cls) is True if obj is an instance
     # of a subclass of cls
     if isinstance(error, exc.ModelContextError):
-        payload[cn.PREDICTION.RESPONSE.KEYS.MODEL_NAME] = error.model_name
-        payload[cn.PREDICTION.RESPONSE.KEYS.MODEL_VERSION] = error.model_version
+        payload[_PREDICTION_KEYS.MODEL_NAME] = error.model_name
+        payload[_PREDICTION_KEYS.MODEL_VERSION] = error.model_version
         payload.update(error.model_meta)
     # getattr() is used to work around werkzeug's bad implementation of
     # HTTPException (i.e. HTTPException inherits from Exception but exposes a
     # different API, namely Exception.message -> HTTPException.description).
     messages = [error.description] if hasattr(error, 'description') else error.args
-    payload[cn.ERRORS.RESPONSE.KEYS.ERROR] = {
-        cn.ERRORS.RESPONSE.KEYS.NAME: type(error).__name__,
-        cn.ERRORS.RESPONSE.KEYS.MESSAGES: messages,
-        cn.ERRORS.RESPONSE.KEYS.TRACEBACK: traceback.format_exc(),
-        cn.ERRORS.RESPONSE.KEYS.USER_DATA: user_data}
+    payload[_ERROR_KEYS.ERROR] = {
+        _ERROR_KEYS.NAME: type(error).__name__,
+        _ERROR_KEYS.MESSAGES: messages,
+        _ERROR_KEYS.TRACEBACK: traceback.format_exc(),
+        _ERROR_KEYS.USER_DATA: user_data}
     return payload
 
 
@@ -99,7 +102,7 @@ def make_ready_response(app_state):
 
 
 def _is_ready(app_state):
-    services = app_state[cn.HEALTH_CHECK.RESPONSE.KEYS.SERVICES]
+    services = app_state[_HEALTH_CHECK_KEYS.SERVICES]
     # app must define services and all services must be ready
-    return services and all(svc[cn.HEALTH_CHECK.RESPONSE.KEYS.STATUS] is _IS_READY
+    return services and all(svc[_HEALTH_CHECK_KEYS.STATUS] is _IS_READY
                             for svc in services.values())

--- a/porter/responses.py
+++ b/porter/responses.py
@@ -15,21 +15,21 @@ _HEALTH_CHECK_KEYS = cn.HEALTH_CHECK.RESPONSE.KEYS
 # that require a context, e.g. `api.jsonify`
 
 
-def make_prediction_response(model_name, model_version, model_meta, id_keys,
+def make_prediction_response(model_name, api_version, model_meta, id_keys,
                              predictions, batch_prediction):
     if batch_prediction:
-        payload = _make_batch_prediction_payload(model_name, model_version, model_meta,
+        payload = _make_batch_prediction_payload(model_name, api_version, model_meta,
                                                  id_keys, predictions)
     else:
-        payload = _make_single_prediction_payload(model_name, model_version, model_meta,
+        payload = _make_single_prediction_payload(model_name, api_version, model_meta,
                                                   id_keys, predictions)
     return api.jsonify(payload)
 
 
-def _make_batch_prediction_payload(model_name, model_version, model_meta, id_keys, predictions):
+def _make_batch_prediction_payload(model_name, api_version, model_meta, id_keys, predictions):
     payload = {
         _PREDICTION_KEYS.MODEL_NAME: model_name,
-        _PREDICTION_KEYS.MODEL_VERSION: model_version,
+        _PREDICTION_KEYS.API_VERSION: api_version,
         _PREDICTION_KEYS.PREDICTIONS: [
             {
                 _PREDICTION_KEYS.ID: id,
@@ -41,10 +41,10 @@ def _make_batch_prediction_payload(model_name, model_version, model_meta, id_key
     return payload
 
 
-def _make_single_prediction_payload(model_name, model_version, model_meta, id_keys, predictions):
+def _make_single_prediction_payload(model_name, api_version, model_meta, id_keys, predictions):
     payload = {
         _PREDICTION_KEYS.MODEL_NAME: model_name,
-        _PREDICTION_KEYS.MODEL_VERSION: model_version,
+        _PREDICTION_KEYS.API_VERSION: api_version,
         _PREDICTION_KEYS.PREDICTIONS:
             {
                 _PREDICTION_KEYS.ID: id_keys[0],
@@ -76,7 +76,7 @@ def _make_error_payload(error, user_data):
     # of a subclass of cls
     if isinstance(error, exc.ModelContextError):
         payload[_PREDICTION_KEYS.MODEL_NAME] = error.model_name
-        payload[_PREDICTION_KEYS.MODEL_VERSION] = error.model_version
+        payload[_PREDICTION_KEYS.API_VERSION] = error.api_version
         payload.update(error.model_meta)
     # getattr() is used to work around werkzeug's bad implementation of
     # HTTPException (i.e. HTTPException inherits from Exception but exposes a

--- a/porter/services.py
+++ b/porter/services.py
@@ -165,6 +165,8 @@ class BaseService(abc.ABC, StatefulRoute):
     _ids = set()
     _logger = logging.getLogger(__name__)
 
+    rotue_kwargs = {}
+
     def __init__(self, *, name, version, meta=None, log_api_calls=False):
         self.name = name
         self.version = version
@@ -283,8 +285,9 @@ class PredictionService(BaseService):
 
     Args:
         name (str): The model name. The final routed endpoint will become
-            "/<endpoint>/prediction/".
-        version (str): The model version.
+            "/<name>/<version>/prediction/".
+        version (str): The model API version. The final routed endpoint
+            will become "/<name>/<version>/prediction/".
         meta (dict): Additional meta data added to the response body.
         log_api_calls (bool): Log request and response and response data.
             Default is False.
@@ -314,13 +317,13 @@ class PredictionService(BaseService):
 
     Attributes:
         id (str): A unique ID for the model. Composed of `name` and `version`.
-        name (str): The model's name. The final routed endpoint will become
-            "/<endpoint>/prediction/".
+        name (str): The model's name.
         meta (dict): Additional meta data added to the response body.
         log_api_calls (bool): Log request and response and response data.
             Default is False.
-        version (str): The model version.
+        version (str): The model API version.
         endpoint (str): The endpoint where the model predictions are exposed.
+            This is computed as "/<name>/<version>/prediction/".
         model (object): An object implementing the interface defined by
             `porter.datascience.BaseModel`.
         preprocessor (object or None): An object implementing the interface
@@ -370,7 +373,8 @@ class PredictionService(BaseService):
         super().__init__(**kwargs)
 
     def define_endpoint(self):
-        return cn.PREDICTION.ENDPOINT_TEMPLATE.format(model_name=self.name)
+        return cn.PREDICTION.ENDPOINT_TEMPLATE.format(
+            model_name=self.name, model_version=self.version)
 
     def check_meta(self, meta):
         """Perform standard meta data checks and inspect meta data keys for
@@ -534,8 +538,9 @@ class MiddlewareService(BaseService):
 
     Args:
         name (str): The model name. The final routed endpoint will become
-            "/<endpoint>/prediction/".
-        version (str): The model version.
+            "/<name>/<version>/prediction/".
+        version (str): The model API version. The final routed endpoint will
+            become "/<name>/<version>/prediction/".
         meta (dict or None): Additional meta data added to the response body.
             Default is None.
         log_api_calls (bool): Log request and response and response data.
@@ -551,14 +556,14 @@ class MiddlewareService(BaseService):
 
     Attributes:
         id (str): A unique ID for the service.
-        name (str): The model name. The final routed endpoint will become
-            "/<endpoint>/batchPrediction/".
-        version (str): The model version.
+        name (str): The model name.
+        version (str): The model API version.
         meta (dict or None): Additional meta data added to the response body.
             Default is None.
         log_api_calls (bool): Log request and response and response data.
             Default is False.
         endpoint (str): The endpoint where the middleware service is exposed.
+            This is computed as "/<name>/<version>/prediction/".
         model_endpoint (str): The URL of the underlying model API.
         max_workers (int or None): The maximum number of workers to use per
             POST request to concurrently send prediction requests to the model
@@ -592,7 +597,8 @@ class MiddlewareService(BaseService):
         return f'{self.name}:middleware:{self.version}'
 
     def define_endpoint(self):
-        return cn.BATCH_PREDICTION.ENDPOINT_TEMPLATE.format(model_name=self.name)
+        return cn.BATCH_PREDICTION.ENDPOINT_TEMPLATE.format(
+            model_name=self.name, model_version=self.version)
 
     def check_meta(self, meta):
         """Perform standard meta data checks and inspect meta data keys for

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -114,11 +114,11 @@ class TestAppPredictions(unittest.TestCase):
             {'id': 5, 'feature1':  3},
         ]
         post_data3 = {'id': 1, 'feature1': 5}
-        actual1 = self.app.post('/a-model/prediction', data=json.dumps(post_data1))
+        actual1 = self.app.post('/a-model/0.0.0/prediction', data=json.dumps(post_data1))
         actual1 = json.loads(actual1.data)
-        actual2 = self.app.post('/another-model/prediction', data=json.dumps(post_data2))
+        actual2 = self.app.post('/another-model/0.1.0/prediction', data=json.dumps(post_data2))
         actual2 = json.loads(actual2.data)
-        actual3 = self.app.post('/model-3/prediction', data=json.dumps(post_data3))
+        actual3 = self.app.post('/model-3/0.0.0-alpha/prediction', data=json.dumps(post_data3))
         actual3 = json.loads(actual3.data)
         expected1 = {
             'model_name': 'a-model',
@@ -165,7 +165,7 @@ class TestAppPredictions(unittest.TestCase):
 
         # only the third service supports instance predictions
         post_data = [{'id': i, 'feature1': i*2} for i in range(10)]
-        actual = self.app.post('/model-3/batchPrediction', data=json.dumps(post_data))
+        actual = self.app.post('/model-3/1.2/batchPrediction', data=json.dumps(post_data))
         actual = json.loads(actual.data)
         expected = [
             {'model_name': 'model-3',
@@ -197,12 +197,12 @@ class TestAppPredictions(unittest.TestCase):
         post_data6 = [{'id': 1, 'feature1': 1, 'feature2': 1},
                       {'id': 1, 'feature1': 0, 'feature2': 1}]
         actuals = [
-            self.app.post('/a-model/prediction', data=json.dumps(post_data1)),
-            self.app.post('/model-3/prediction', data=json.dumps(post_data2)),
-            self.app.post('/another-model/prediction', data=json.dumps(post_data3)),
-            self.app.post('/model-3/prediction', data=json.dumps(post_data4)),
-            self.app.post('/a-model/prediction', data=json.dumps(post_data5)),
-            self.app.post('/another-model/prediction', data=json.dumps(post_data6)),
+            self.app.post('/a-model/0.0.0/prediction', data=json.dumps(post_data1)),
+            self.app.post('/model-3/0.0.0-alpha/prediction', data=json.dumps(post_data2)),
+            self.app.post('/another-model/0.1.0/prediction', data=json.dumps(post_data3)),
+            self.app.post('/model-3/0.0.0-alpha/prediction', data=json.dumps(post_data4)),
+            self.app.post('/a-model/0.0.0/prediction', data=json.dumps(post_data5)),
+            self.app.post('/another-model/0.1.0/prediction', data=json.dumps(post_data6)),
         ]
         # check status codes
         self.assertTrue(all(actual.status_code == 400 for actual in actuals))
@@ -265,7 +265,7 @@ class TestAppHealthChecks(unittest.TestCase):
         cf.name = 'model1'
         cf.version = '1.0.0'
         cf.id = 'model1'
-        cf.endpoint = '/model1/prediction'
+        cf.endpoint = '/model1/1.0.0/prediction'
         cf.meta = {'foo': 1, 'bar': 2}
         self.model_app.add_service(cf)
         resp_alive = self.app.get('/-/alive')
@@ -278,7 +278,7 @@ class TestAppHealthChecks(unittest.TestCase):
                     'status': 'READY',
                     'name': 'model1',
                     'version': '1.0.0',
-                    'endpoint': '/model1/prediction',
+                    'endpoint': '/model1/1.0.0/prediction',
                     'meta': {'foo': 1, 'bar': 2}
                 }
             }
@@ -296,13 +296,13 @@ class TestAppHealthChecks(unittest.TestCase):
         cf1.name = 'model1'
         cf1.version = '1.0.0'
         cf1.id = 'model1:1.0.0'
-        cf1.endpoint = '/model1/prediction'
+        cf1.endpoint = '/model1/1.0.0/prediction'
         cf1.meta = {'foo': 1, 'bar': 2}
         cf2 = PredictionService()
         cf2.name = 'model2'
         cf2.version = '0.0.0'
         cf2.id = 'model2:0.0.0'
-        cf2.endpoint = '/model2/prediction'
+        cf2.endpoint = '/model2/0.0.0/prediction'
         cf2.meta = {'foo': 1}
         self.model_app.add_services(cf1, cf2)
         resp_alive = self.app.get('/-/alive')
@@ -315,14 +315,14 @@ class TestAppHealthChecks(unittest.TestCase):
                     'status': 'READY',
                     'name': 'model1',
                     'version': '1.0.0',
-                    'endpoint': '/model1/prediction',
+                    'endpoint': '/model1/1.0.0/prediction',
                     'meta': {'foo': 1, 'bar': 2},
                 },
                 'model2:0.0.0': {
                     'status': 'READY',
                     'name': 'model2',
                     'version': '0.0.0',
-                    'endpoint': '/model2/prediction',
+                    'endpoint': '/model2/0.0.0/prediction',
                     'meta': {'foo': 1},
                 }
             }
@@ -433,7 +433,7 @@ class TestAppErrorHandling(unittest.TestCase):
     def test_prediction_fails(self, mock__predict):
         mock__predict.side_effect = Exception('testing a failing model')
         user_data = {'some test': 'data'}
-        resp = self.app_test_client.post('/failing-model/prediction', data=json.dumps(user_data))
+        resp = self.app_test_client.post('/failing-model/B/prediction', data=json.dumps(user_data))
         actual = json.loads(resp.data)
         expected = {
             'model_name': 'failing-model',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -58,7 +58,7 @@ class TestAppPredictions(unittest.TestCase):
         prediction_service1 = PredictionService(
             model=Model1(),
             name='a-model',
-            version='v0',
+            api_version='v0',
             preprocessor=Preprocessor1(),
             postprocessor=Postprocessor1(),
             input_features=input_features1,
@@ -68,7 +68,7 @@ class TestAppPredictions(unittest.TestCase):
         prediction_service2 = PredictionService(
             model=Model2(),
             name='anotherModel',
-            version='v1',
+            api_version='v1',
             preprocessor=Preprocessor2(),
             postprocessor=None,
             input_features=input_features2,
@@ -79,7 +79,7 @@ class TestAppPredictions(unittest.TestCase):
         prediction_service3 = PredictionService(
             model=Model3(),
             name='model-3',
-            version='v0.0-alpha',
+            api_version='v0.0-alpha',
             preprocessor=None,
             postprocessor=None,
             input_features=input_features3,
@@ -90,7 +90,7 @@ class TestAppPredictions(unittest.TestCase):
         with mock.patch('porter.services.api', **{'validate_url.return_value': True}):
             middleware_service = MiddlewareService(
                 name='model-3',
-                version='version1',
+                api_version='version1',
                 model_endpoint=prediction_service3.endpoint,
                 max_workers=None)
         cls.model_app.add_service(prediction_service1)
@@ -122,7 +122,7 @@ class TestAppPredictions(unittest.TestCase):
         actual3 = json.loads(actual3.data)
         expected1 = {
             'model_name': 'a-model',
-            'model_version': 'v0',
+            'api_version': 'v0',
             'predictions': [
                 {'id': 1, 'prediction': 0},
                 {'id': 2, 'prediction': -2},
@@ -133,7 +133,7 @@ class TestAppPredictions(unittest.TestCase):
         }
         expected2 = {
             'model_name': 'anotherModel',
-            'model_version': 'v1',
+            'api_version': 'v1',
             'predictions': [
                 {'id': 1, 'prediction': 10},
                 {'id': 2, 'prediction': 11},
@@ -144,7 +144,7 @@ class TestAppPredictions(unittest.TestCase):
         }
         expected3 = {
             'model_name': 'model-3',
-            'model_version': 'v0.0-alpha',
+            'api_version': 'v0.0-alpha',
             'algorithm': 'randomforest',
             'lasttrained': 1,
             'predictions': {'id': 1, 'prediction': -5}
@@ -169,7 +169,7 @@ class TestAppPredictions(unittest.TestCase):
         actual = json.loads(actual.data)
         expected = [
             {'model_name': 'model-3',
-             'model_version': 'v0.0-alpha',
+             'api_version': 'v0.0-alpha',
              'algorithm': 'randomforest',
              'lasttrained': 1,
              'predictions': {'id': d['id'], 'prediction': -d['feature1']}}
@@ -223,12 +223,12 @@ class TestAppPredictions(unittest.TestCase):
                 self.assertEqual(actual_error_obj[key], value)
         # check that model context data is passed into responses
         expected_model_context_values = [
-            {'model_name': 'a-model', 'model_version': 'v0'},
-            {'model_name': 'model-3', 'model_version': 'v0.0-alpha', 'algorithm': 'randomforest', 'lasttrained': 1},
-            {'model_name': 'anotherModel', 'model_version': 'v1'},
-            {'model_name': 'model-3', 'model_version': 'v0.0-alpha', 'algorithm': 'randomforest', 'lasttrained': 1},
-            {'model_name': 'a-model', 'model_version': 'v0'},
-            {'model_name': 'anotherModel', 'model_version': 'v1'},
+            {'model_name': 'a-model', 'api_version': 'v0'},
+            {'model_name': 'model-3', 'api_version': 'v0.0-alpha', 'algorithm': 'randomforest', 'lasttrained': 1},
+            {'model_name': 'anotherModel', 'api_version': 'v1'},
+            {'model_name': 'model-3', 'api_version': 'v0.0-alpha', 'algorithm': 'randomforest', 'lasttrained': 1},
+            {'model_name': 'a-model', 'api_version': 'v0'},
+            {'model_name': 'anotherModel', 'api_version': 'v1'},
         ]
         for actual, expectations in zip(actuals, expected_model_context_values):
             actual_error_obj = json.loads(actual.data)
@@ -263,7 +263,7 @@ class TestAppHealthChecks(unittest.TestCase):
         mock_init.return_value = None
         cf = PredictionService()
         cf.name = 'model1'
-        cf.version = '1.0.0'
+        cf.api_version = '1.0.0'
         cf.id = 'model1'
         cf.endpoint = '/model1/1.0.0/prediction'
         cf.meta = {'foo': 1, 'bar': 2}
@@ -277,7 +277,7 @@ class TestAppHealthChecks(unittest.TestCase):
                 'model1': {
                     'status': 'READY',
                     'name': 'model1',
-                    'version': '1.0.0',
+                    'api_version': '1.0.0',
                     'endpoint': '/model1/1.0.0/prediction',
                     'meta': {'foo': 1, 'bar': 2}
                 }
@@ -294,13 +294,13 @@ class TestAppHealthChecks(unittest.TestCase):
         mock_init.return_value = None
         cf1 = PredictionService()
         cf1.name = 'model1'
-        cf1.version = '1.0.0'
+        cf1.api_version = '1.0.0'
         cf1.id = 'model1:1.0.0'
         cf1.endpoint = '/model1/1.0.0/prediction'
         cf1.meta = {'foo': 1, 'bar': 2}
         cf2 = PredictionService()
         cf2.name = 'model2'
-        cf2.version = 'v0'
+        cf2.api_version = 'v0'
         cf2.id = 'model2:v0'
         cf2.endpoint = '/model2/v0/prediction'
         cf2.meta = {'foo': 1}
@@ -314,14 +314,14 @@ class TestAppHealthChecks(unittest.TestCase):
                 'model1:1.0.0': {
                     'status': 'READY',
                     'name': 'model1',
-                    'version': '1.0.0',
+                    'api_version': '1.0.0',
                     'endpoint': '/model1/1.0.0/prediction',
                     'meta': {'foo': 1, 'bar': 2},
                 },
                 'model2:v0': {
                     'status': 'READY',
                     'name': 'model2',
-                    'version': 'v0',
+                    'api_version': 'v0',
                     'endpoint': '/model2/v0/prediction',
                     'meta': {'foo': 1},
                 }
@@ -437,7 +437,7 @@ class TestAppErrorHandling(unittest.TestCase):
         actual = json.loads(resp.data)
         expected = {
             'model_name': 'failing-model',
-            'model_version': 'B',
+            'api_version': 'B',
             '1': 'one',
             'two': 2,
             'error': {
@@ -449,7 +449,7 @@ class TestAppErrorHandling(unittest.TestCase):
         }
         self.assertEqual(resp.status_code, 500)
         self.assertEqual(actual['model_name'], expected['model_name'])
-        self.assertEqual(actual['model_version'], expected['model_version'])
+        self.assertEqual(actual['api_version'], expected['api_version'])
         self.assertEqual(actual['1'], expected['1'])
         self.assertEqual(actual['two'], expected['two'])
         self.assertEqual(actual['error']['name'], expected['error']['name'])
@@ -460,7 +460,7 @@ class TestAppErrorHandling(unittest.TestCase):
     @classmethod
     def add_failing_model_service(cls):
         prediction_service = PredictionService(name='failing-model',
-            version='B', model=None, meta={'1': 'one', 'two': 2})
+            api_version='B', model=None, meta={'1': 'one', 'two': 2})
         cls.model_app.add_service(prediction_service)
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -58,7 +58,7 @@ class TestAppPredictions(unittest.TestCase):
         prediction_service1 = PredictionService(
             model=Model1(),
             name='a-model',
-            version='0.0.0',
+            version='v0',
             preprocessor=Preprocessor1(),
             postprocessor=Postprocessor1(),
             input_features=input_features1,
@@ -67,8 +67,8 @@ class TestAppPredictions(unittest.TestCase):
         )
         prediction_service2 = PredictionService(
             model=Model2(),
-            name='another-model',
-            version='0.1.0',
+            name='anotherModel',
+            version='v1',
             preprocessor=Preprocessor2(),
             postprocessor=None,
             input_features=input_features2,
@@ -79,7 +79,7 @@ class TestAppPredictions(unittest.TestCase):
         prediction_service3 = PredictionService(
             model=Model3(),
             name='model-3',
-            version='0.0.0-alpha',
+            version='v0.0-alpha',
             preprocessor=None,
             postprocessor=None,
             input_features=input_features3,
@@ -90,7 +90,7 @@ class TestAppPredictions(unittest.TestCase):
         with mock.patch('porter.services.api', **{'validate_url.return_value': True}):
             middleware_service = MiddlewareService(
                 name='model-3',
-                version='1.2',
+                version='version1',
                 model_endpoint=prediction_service3.endpoint,
                 max_workers=None)
         cls.model_app.add_service(prediction_service1)
@@ -114,15 +114,15 @@ class TestAppPredictions(unittest.TestCase):
             {'id': 5, 'feature1':  3},
         ]
         post_data3 = {'id': 1, 'feature1': 5}
-        actual1 = self.app.post('/a-model/0.0.0/prediction', data=json.dumps(post_data1))
+        actual1 = self.app.post('/a-model/v0/prediction', data=json.dumps(post_data1))
         actual1 = json.loads(actual1.data)
-        actual2 = self.app.post('/another-model/0.1.0/prediction', data=json.dumps(post_data2))
+        actual2 = self.app.post('/anotherModel/v1/prediction', data=json.dumps(post_data2))
         actual2 = json.loads(actual2.data)
-        actual3 = self.app.post('/model-3/0.0.0-alpha/prediction', data=json.dumps(post_data3))
+        actual3 = self.app.post('/model-3/v0.0-alpha/prediction', data=json.dumps(post_data3))
         actual3 = json.loads(actual3.data)
         expected1 = {
             'model_name': 'a-model',
-            'model_version': '0.0.0',
+            'model_version': 'v0',
             'predictions': [
                 {'id': 1, 'prediction': 0},
                 {'id': 2, 'prediction': -2},
@@ -132,8 +132,8 @@ class TestAppPredictions(unittest.TestCase):
             ]
         }
         expected2 = {
-            'model_name': 'another-model',
-            'model_version': '0.1.0',
+            'model_name': 'anotherModel',
+            'model_version': 'v1',
             'predictions': [
                 {'id': 1, 'prediction': 10},
                 {'id': 2, 'prediction': 11},
@@ -144,7 +144,7 @@ class TestAppPredictions(unittest.TestCase):
         }
         expected3 = {
             'model_name': 'model-3',
-            'model_version': '0.0.0-alpha',
+            'model_version': 'v0.0-alpha',
             'algorithm': 'randomforest',
             'lasttrained': 1,
             'predictions': {'id': 1, 'prediction': -5}
@@ -165,11 +165,11 @@ class TestAppPredictions(unittest.TestCase):
 
         # only the third service supports instance predictions
         post_data = [{'id': i, 'feature1': i*2} for i in range(10)]
-        actual = self.app.post('/model-3/1.2/batchPrediction', data=json.dumps(post_data))
+        actual = self.app.post('/model-3/version1/batchPrediction', data=json.dumps(post_data))
         actual = json.loads(actual.data)
         expected = [
             {'model_name': 'model-3',
-             'model_version': '0.0.0-alpha',
+             'model_version': 'v0.0-alpha',
              'algorithm': 'randomforest',
              'lasttrained': 1,
              'predictions': {'id': d['id'], 'prediction': -d['feature1']}}
@@ -197,12 +197,12 @@ class TestAppPredictions(unittest.TestCase):
         post_data6 = [{'id': 1, 'feature1': 1, 'feature2': 1},
                       {'id': 1, 'feature1': 0, 'feature2': 1}]
         actuals = [
-            self.app.post('/a-model/0.0.0/prediction', data=json.dumps(post_data1)),
-            self.app.post('/model-3/0.0.0-alpha/prediction', data=json.dumps(post_data2)),
-            self.app.post('/another-model/0.1.0/prediction', data=json.dumps(post_data3)),
-            self.app.post('/model-3/0.0.0-alpha/prediction', data=json.dumps(post_data4)),
-            self.app.post('/a-model/0.0.0/prediction', data=json.dumps(post_data5)),
-            self.app.post('/another-model/0.1.0/prediction', data=json.dumps(post_data6)),
+            self.app.post('/a-model/v0/prediction', data=json.dumps(post_data1)),
+            self.app.post('/model-3/v0.0-alpha/prediction', data=json.dumps(post_data2)),
+            self.app.post('/anotherModel/v1/prediction', data=json.dumps(post_data3)),
+            self.app.post('/model-3/v0.0-alpha/prediction', data=json.dumps(post_data4)),
+            self.app.post('/a-model/v0/prediction', data=json.dumps(post_data5)),
+            self.app.post('/anotherModel/v1/prediction', data=json.dumps(post_data6)),
         ]
         # check status codes
         self.assertTrue(all(actual.status_code == 400 for actual in actuals))
@@ -223,12 +223,12 @@ class TestAppPredictions(unittest.TestCase):
                 self.assertEqual(actual_error_obj[key], value)
         # check that model context data is passed into responses
         expected_model_context_values = [
-            {'model_name': 'a-model', 'model_version': '0.0.0'},
-            {'model_name': 'model-3', 'model_version': '0.0.0-alpha', 'algorithm': 'randomforest', 'lasttrained': 1},
-            {'model_name': 'another-model', 'model_version': '0.1.0'},
-            {'model_name': 'model-3', 'model_version': '0.0.0-alpha', 'algorithm': 'randomforest', 'lasttrained': 1},
-            {'model_name': 'a-model', 'model_version': '0.0.0'},
-            {'model_name': 'another-model', 'model_version': '0.1.0'},
+            {'model_name': 'a-model', 'model_version': 'v0'},
+            {'model_name': 'model-3', 'model_version': 'v0.0-alpha', 'algorithm': 'randomforest', 'lasttrained': 1},
+            {'model_name': 'anotherModel', 'model_version': 'v1'},
+            {'model_name': 'model-3', 'model_version': 'v0.0-alpha', 'algorithm': 'randomforest', 'lasttrained': 1},
+            {'model_name': 'a-model', 'model_version': 'v0'},
+            {'model_name': 'anotherModel', 'model_version': 'v1'},
         ]
         for actual, expectations in zip(actuals, expected_model_context_values):
             actual_error_obj = json.loads(actual.data)
@@ -300,9 +300,9 @@ class TestAppHealthChecks(unittest.TestCase):
         cf1.meta = {'foo': 1, 'bar': 2}
         cf2 = PredictionService()
         cf2.name = 'model2'
-        cf2.version = '0.0.0'
-        cf2.id = 'model2:0.0.0'
-        cf2.endpoint = '/model2/0.0.0/prediction'
+        cf2.version = 'v0'
+        cf2.id = 'model2:v0'
+        cf2.endpoint = '/model2/v0/prediction'
         cf2.meta = {'foo': 1}
         self.model_app.add_services(cf1, cf2)
         resp_alive = self.app.get('/-/alive')
@@ -318,11 +318,11 @@ class TestAppHealthChecks(unittest.TestCase):
                     'endpoint': '/model1/1.0.0/prediction',
                     'meta': {'foo': 1, 'bar': 2},
                 },
-                'model2:0.0.0': {
+                'model2:v0': {
                     'status': 'READY',
                     'name': 'model2',
-                    'version': '0.0.0',
-                    'endpoint': '/model2/0.0.0/prediction',
+                    'version': 'v0',
+                    'endpoint': '/model2/v0/prediction',
                     'meta': {'foo': 1},
                 }
             }

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -56,12 +56,12 @@ class TestExample(unittest.TestCase):
         response = test_client.post('/supa-dupa-model/v1/prediction', data=json.dumps(app_input, cls=NumpyEncoder))
         actual_response_data = json.loads(response.data)
         expected_model_name = 'supa-dupa-model'
-        expected_model_version = 'v1'
+        expected_api_version = 'v1'
         expected_predictions = {
             id_: pred for id_, pred in zip(self.X['id'], self.predictions)
         }
         self.assertEqual(actual_response_data['model_name'], expected_model_name)
-        self.assertEqual(actual_response_data['model_version'], expected_model_version)
+        self.assertEqual(actual_response_data['api_version'], expected_api_version)
         for rec in actual_response_data['predictions']:
             actual_id, actual_pred = rec['id'], rec['prediction']
             expected_pred = expected_predictions[actual_id]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -53,10 +53,10 @@ class TestExample(unittest.TestCase):
             namespace = load_example(os.path.join(HERE, '../examples/example.py'), init_namespace)
         test_client = namespace['model_app'].app.test_client()
         app_input = self.X.to_dict('records')
-        response = test_client.post('/supa-dupa-model/prediction', data=json.dumps(app_input, cls=NumpyEncoder))
+        response = test_client.post('/supa-dupa-model/v1/prediction', data=json.dumps(app_input, cls=NumpyEncoder))
         actual_response_data = json.loads(response.data)
         expected_model_name = 'supa-dupa-model'
-        expected_model_version = '1.0.0'
+        expected_model_version = 'v1'
         expected_predictions = {
             id_: pred for id_, pred in zip(self.X['id'], self.predictions)
         }

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -12,7 +12,7 @@ class TestFunctions(unittest.TestCase):
         actual = _make_batch_prediction_payload('a-model', '1', {1: '2', '3': 4}, [1, 2, 3], [10.0, 11.0, 12.0])
         expected = {
             'model_name': 'a-model',
-            'model_version': '1',
+            'api_version': '1',
             1: '2',
             '3': 4,
             'predictions': [
@@ -27,7 +27,7 @@ class TestFunctions(unittest.TestCase):
         actual = _make_single_prediction_payload('a-model', '1', {1: '2', '3': 4}, [1], [10.0])
         expected = {
             'model_name': 'a-model',
-            'model_version': '1',
+            'api_version': '1',
             1: '2',
             '3': 4,
             'predictions': {'id': 1, 'prediction': 10.0}
@@ -57,7 +57,7 @@ class TestFunctions(unittest.TestCase):
 
     def test__make_error_payload_porter_error(self):
         error = PredictionError('foo bar baz')
-        error.update_model_context(model_name='M', model_version='V',
+        error.update_model_context(model_name='M', api_version='V',
             model_meta={1: '1', '2': 2})
         try:
             raise error
@@ -65,7 +65,7 @@ class TestFunctions(unittest.TestCase):
             actual = _make_error_payload(error, 'foo')
         expected = {
             'model_name': 'M',
-            'model_version': 'V',
+            'api_version': 'V',
             1: '1',
             '2': 2,
             'error': {

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -184,10 +184,11 @@ class TestPredictionService(unittest.TestCase):
         mock_preprocessor.process.return_value = {}
         mock_postprocessor = mock.Mock()
         mock_postprocessor.process.return_value = []
+        model_name = model_version = mock.MagicMock()
         serve_prediction = PredictionService(
             model=mock_model,
-            name=mock.Mock(),
-            version=mock.Mock(),
+            name=model_name,
+            version=model_version,
             meta={},
             allow_nulls=mock.Mock(),
             preprocessor=mock_preprocessor,
@@ -204,7 +205,8 @@ class TestPredictionService(unittest.TestCase):
     @mock.patch('porter.services.BaseService._ids', set())
     def test_serve_no_processing_batch(self, mock_flask_jsonify, mock_flask_request):
         # make sure it doesn't break when processors are None
-        model = model_name = model_version = allow_nulls = mock.Mock()
+        model = allow_nulls = mock.Mock()
+        model_name = model_version = mock.MagicMock()
         mock_flask_request.get_json.return_value = [{'id': None}]
         model.predict.return_value = []
         serve_prediction = PredictionService(
@@ -223,7 +225,8 @@ class TestPredictionService(unittest.TestCase):
     @mock.patch('flask.request')
     @mock.patch('flask.jsonify')
     def test_serve_with_processing_single(self, mock_flask_jsonify, mock_flask_request):
-        model = model_name = model_version = allow_nulls = mock.Mock()
+        model = allow_nulls = mock.Mock()
+        model_name = model_version = mock.MagicMock()
         mock_flask_request.get_json.return_value = {'id': None}
         model.predict.return_value = [1]
         mock_preprocessor = mock.Mock()
@@ -250,7 +253,8 @@ class TestPredictionService(unittest.TestCase):
     @mock.patch('porter.services.BaseService._ids', set())
     def test_serve_no_processing_single(self, mock_flask_jsonify, mock_flask_request):
         # make sure it doesn't break when processors are None
-        model = model_name = model_version = allow_nulls = mock.Mock()
+        model = allow_nulls = mock.Mock()
+        model_name = model_version = mock.MagicMock()
         mock_flask_request.get_json.return_value = {'id': None}
         model.predict.return_value = [1]
         serve_prediction = PredictionService(
@@ -334,13 +338,14 @@ class TestPredictionService(unittest.TestCase):
     def test_get_post_data_batch_prediction(self, mock_responses_api, mock_services_api):
         mock_model = mock.Mock()
         mock_model.predict.return_value = []
+        mock_name = mock_version = mock.MagicMock()
 
         # Succeed
         mock_services_api.request_json.return_value = [{'id': None}]
         serve_prediction = PredictionService(
             model=mock_model,
-            name=mock.Mock(),
-            version=mock.Mock(),
+            name=mock_name,
+            version=mock_version,
             meta={},
             allow_nulls=mock.Mock(),
             preprocessor=None,
@@ -355,8 +360,8 @@ class TestPredictionService(unittest.TestCase):
         mock_services_api.request_json.return_value = {'id': None}
         serve_prediction = PredictionService(
             model=mock_model,
-            name=mock.Mock(),
-            version=mock.Mock(),
+            name=mock.MagicMock(),
+            version=mock.MagicMock(),
             meta={},
             allow_nulls=mock.Mock(),
             preprocessor=None,
@@ -378,8 +383,8 @@ class TestPredictionService(unittest.TestCase):
         mock_services_api.request_json.return_value = {'id': None}
         serve_prediction = PredictionService(
             model=mock_model,
-            name=mock.Mock(),
-            version=mock.Mock(),
+            name=mock.MagicMock(),
+            version=mock.MagicMock(),
             meta={},
             allow_nulls=mock.Mock(),
             preprocessor=None,
@@ -394,8 +399,8 @@ class TestPredictionService(unittest.TestCase):
         mock_services_api.request_json.return_value = [{'id': None}]
         serve_prediction = PredictionService(
             model=mock.Mock(),
-            name=mock.Mock(),
-            version=mock.Mock(),
+            name=mock.MagicMock(),
+            version=mock.MagicMock(),
             meta={},
             allow_nulls=mock.Mock(),
             preprocessor=None,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -66,7 +66,7 @@ class TestPredictionService(unittest.TestCase):
         ]
         mock_model = mock.Mock()
         test_model_name = 'model'
-        test_model_version = '1.0.0'
+        test_api_version = '1.0.0'
         mock_preprocessor = mock.Mock()
         mock_postprocessor = mock.Mock()
         allow_nulls = False
@@ -84,7 +84,7 @@ class TestPredictionService(unittest.TestCase):
         serve_prediction = PredictionService(
             model=mock_model,
             name=test_model_name,
-            version=test_model_version,
+            api_version=test_api_version,
             meta={'1': '2', '3': 4},
             preprocessor=mock_preprocessor,
             postprocessor=mock_postprocessor,
@@ -95,7 +95,7 @@ class TestPredictionService(unittest.TestCase):
         actual = serve_prediction()
         expected = {
             'model_name': test_model_name,
-            'model_version': test_model_version,
+            'api_version': test_api_version,
             '1': '2',
             '3': 4,
             'predictions': [
@@ -116,7 +116,7 @@ class TestPredictionService(unittest.TestCase):
         mock_request_json.return_value = {'id': 1, 'feature1': 10, 'feature2': 0}
         mock_model = mock.Mock()
         test_model_name = 'model'
-        test_model_version = '1.0.0'
+        test_api_version = '1.0.0'
         mock_preprocessor = mock.Mock()
         mock_postprocessor = mock.Mock()
         allow_nulls = False
@@ -134,7 +134,7 @@ class TestPredictionService(unittest.TestCase):
         serve_prediction = PredictionService(
             model=mock_model,
             name=test_model_name,
-            version=test_model_version,
+            api_version=test_api_version,
             meta={'1': '2', '3': 4},
             preprocessor=mock_preprocessor,
             postprocessor=mock_postprocessor,
@@ -145,7 +145,7 @@ class TestPredictionService(unittest.TestCase):
         actual = serve_prediction()
         expected = {
             'model_name': test_model_name,
-            'model_version': test_model_version,
+            'api_version': test_api_version,
             '1': '2',
             '3': 4,
             'predictions': {'id': 1, 'prediction': 20}
@@ -164,14 +164,14 @@ class TestPredictionService(unittest.TestCase):
         meta = {}
         with self.assertRaises(exc.PredictionError) as ctx:
             sp = PredictionService(
-                model=mock.Mock(), name=name, version=version,
+                model=mock.Mock(), name=name, api_version=version,
                 meta=meta, preprocessor=mock.Mock(), postprocessor=mock.Mock(),
                 allow_nulls=mock.Mock(), batch_prediction=mock.Mock(),
                 additional_checks=mock.Mock())
             sp()
             # porter.responses.make_error_response counts on these attributes being filled out
             self.assertEqual(ctx.exception.model_name, name)
-            self.assertEqual(ctx.exception.model_version, version)
+            self.assertEqual(ctx.exception.api_version, version)
             self.assertEqual(ctx.exception.model_meta, meta)
 
     @mock.patch('flask.request')
@@ -184,11 +184,11 @@ class TestPredictionService(unittest.TestCase):
         mock_preprocessor.process.return_value = {}
         mock_postprocessor = mock.Mock()
         mock_postprocessor.process.return_value = []
-        model_name = model_version = mock.MagicMock()
+        model_name = api_version = mock.MagicMock()
         serve_prediction = PredictionService(
             model=mock_model,
             name=model_name,
-            version=model_version,
+            api_version=api_version,
             meta={},
             allow_nulls=mock.Mock(),
             preprocessor=mock_preprocessor,
@@ -206,13 +206,13 @@ class TestPredictionService(unittest.TestCase):
     def test_serve_no_processing_batch(self, mock_flask_jsonify, mock_flask_request):
         # make sure it doesn't break when processors are None
         model = allow_nulls = mock.Mock()
-        model_name = model_version = mock.MagicMock()
+        model_name = api_version = mock.MagicMock()
         mock_flask_request.get_json.return_value = [{'id': None}]
         model.predict.return_value = []
         serve_prediction = PredictionService(
             model=model,
             name=model_name,
-            version=model_version,
+            api_version=api_version,
             meta={},
             allow_nulls=allow_nulls,
             preprocessor=None,
@@ -226,7 +226,7 @@ class TestPredictionService(unittest.TestCase):
     @mock.patch('flask.jsonify')
     def test_serve_with_processing_single(self, mock_flask_jsonify, mock_flask_request):
         model = allow_nulls = mock.Mock()
-        model_name = model_version = mock.MagicMock()
+        model_name = api_version = mock.MagicMock()
         mock_flask_request.get_json.return_value = {'id': None}
         model.predict.return_value = [1]
         mock_preprocessor = mock.Mock()
@@ -236,7 +236,7 @@ class TestPredictionService(unittest.TestCase):
         serve_prediction = PredictionService(
             model=model,
             name=model_name,
-            version=model_version,
+            api_version=api_version,
             meta={},
             allow_nulls=allow_nulls,
             preprocessor=mock_preprocessor,
@@ -254,13 +254,13 @@ class TestPredictionService(unittest.TestCase):
     def test_serve_no_processing_single(self, mock_flask_jsonify, mock_flask_request):
         # make sure it doesn't break when processors are None
         model = allow_nulls = mock.Mock()
-        model_name = model_version = mock.MagicMock()
+        model_name = api_version = mock.MagicMock()
         mock_flask_request.get_json.return_value = {'id': None}
         model.predict.return_value = [1]
         serve_prediction = PredictionService(
             model=model,
             name=model_name,
-            version=model_version,
+            api_version=api_version,
             meta={},
             allow_nulls=allow_nulls,
             preprocessor=None,
@@ -345,7 +345,7 @@ class TestPredictionService(unittest.TestCase):
         serve_prediction = PredictionService(
             model=mock_model,
             name=mock_name,
-            version=mock_version,
+            api_version=mock_version,
             meta={},
             allow_nulls=mock.Mock(),
             preprocessor=None,
@@ -361,7 +361,7 @@ class TestPredictionService(unittest.TestCase):
         serve_prediction = PredictionService(
             model=mock_model,
             name=mock.MagicMock(),
-            version=mock.MagicMock(),
+            api_version=mock.MagicMock(),
             meta={},
             allow_nulls=mock.Mock(),
             preprocessor=None,
@@ -384,7 +384,7 @@ class TestPredictionService(unittest.TestCase):
         serve_prediction = PredictionService(
             model=mock_model,
             name=mock.MagicMock(),
-            version=mock.MagicMock(),
+            api_version=mock.MagicMock(),
             meta={},
             allow_nulls=mock.Mock(),
             preprocessor=None,
@@ -400,7 +400,7 @@ class TestPredictionService(unittest.TestCase):
         serve_prediction = PredictionService(
             model=mock.Mock(),
             name=mock.MagicMock(),
-            version=mock.MagicMock(),
+            api_version=mock.MagicMock(),
             meta={},
             allow_nulls=mock.Mock(),
             preprocessor=None,
@@ -415,7 +415,7 @@ class TestPredictionService(unittest.TestCase):
     @mock.patch('porter.services.BaseService._ids', set())
     def test_constructor(self):
         service_config = PredictionService(
-            model=None, name='foo', version='bar', meta={'1': '2', '3': 4})
+            model=None, name='foo', api_version='bar', meta={'1': '2', '3': 4})
 
     @mock.patch('porter.services.PredictionService.reserved_keys', ['1', '2'])
     @mock.patch('porter.services.BaseService._ids', set())
@@ -423,10 +423,10 @@ class TestPredictionService(unittest.TestCase):
         with self.assertRaisesRegex(exc.PorterError, 'Could not jsonify meta data'):
             with mock.patch('porter.services.cf.json_encoder', spec={'encode.side_effect': TypeError}) as mock_encoder:
                 service_config = PredictionService(
-                    model=None, name='foo', version='bar', meta=object())
+                    model=None, name='foo', api_version='bar', meta=object())
         with self.assertRaisesRegex(exc.PorterError, '.*keys are reserved for prediction.*'):
             service_config = PredictionService(
-                model=None, name='foo', version='bar', meta={'1': '2', '3': 4})
+                model=None, name='foo', api_version='bar', meta={'1': '2', '3': 4})
         with self.assertRaisesRegex(exc.PorterError, '.*callable.*'):
             service_config = PredictionService(
                 model=None, additional_checks=1)
@@ -466,18 +466,18 @@ class TestMiddlewareService(unittest.TestCase):
         meta = {}
         with self.assertRaises(exc.PredictionError) as ctx:
             sp = MiddlewareService(
-                name=name, version=version,
+                name=name, api_version=version,
                 meta=meta, model_endpoint=mock.Mock(), max_workers=mock.Mock())
             sp()
             # porter.responses.make_error_response counts on these attributes being filled out
             self.assertEqual(ctx.exception.model_name, name)
-            self.assertEqual(ctx.exception.model_version, version)
+            self.assertEqual(ctx.exception.api_version, version)
             self.assertEqual(ctx.exception.model_meta, meta)
 
     def test_constructor(self):
         middleware_service = MiddlewareService(
             name='a-model',
-            version='v1',
+            api_version='v1',
             meta={'foo': 1, 'bar': 'baz'},
             model_endpoint='http://localhost:5000/a-model/prediction',
             max_workers=20
@@ -488,7 +488,7 @@ class TestMiddlewareService(unittest.TestCase):
                          'model_endpoint': 'http://localhost:5000/a-model/prediction',
                          'max_workers': 20}
         self.assertEqual(middleware_service.name, 'a-model')
-        self.assertEqual(middleware_service.version, 'v1')
+        self.assertEqual(middleware_service.api_version, 'v1')
         self.assertEqual(middleware_service.id, expected_id)
         self.assertEqual(middleware_service.endpoint, expected_endpoint)
         self.assertEqual(middleware_service.meta, expected_meta)
@@ -498,7 +498,7 @@ class TestMiddlewareService(unittest.TestCase):
         with self.assertRaisesRegex(exc.PorterError, 'url'):
             middleware_service = MiddlewareService(
                     name='a-model',
-                    version='1.0',
+                    api_version='1.0',
                     meta={'foo': 1, 'bar': 'baz'},
                     model_endpoint='localhost:5000/a-model/prediction',
                     max_workers=20
@@ -510,7 +510,7 @@ class TestMiddlewareService(unittest.TestCase):
         with self.assertRaisesRegex(exc.PorterError, 'url'):
             middleware_service = MiddlewareService(
                 name='a-model',
-                version='1.0',
+                api_version='1.0',
                 meta={'foo': 1, 'bar': 'baz'},
                 model_endpoint='http://localhost:5000/a-model/prediction',
                 max_workers=20
@@ -582,7 +582,7 @@ class TestModelApp(unittest.TestCase):
         class service1:
             id = 'service1'
             name = 'foo'
-            version = 'bar'
+            api_version = 'bar'
             endpoint = '/an/endpoint'
             meta = {'key1': 'value1', 'key2': 2}
             status = 'ready'
@@ -590,7 +590,7 @@ class TestModelApp(unittest.TestCase):
         class service2:
             id = 'service2'
             name = 'foobar'
-            version = '1'
+            api_version = '1'
             endpoint = '/foobar'
             meta = {}
             status = 'ready'
@@ -598,7 +598,7 @@ class TestModelApp(unittest.TestCase):
         class service3:
             id = 'service3'
             name = 'supa-dupa-model'
-            version = '1.0'
+            api_version = '1.0'
             endpoint = '/supa/dupa'
             meta = {'key1': 1}
             status = 'not ready'
@@ -613,21 +613,21 @@ class TestModelApp(unittest.TestCase):
             'services': {
                 'service1': {
                     'name': 'foo',
-                    'version': 'bar',
+                    'api_version': 'bar',
                     'endpoint': '/an/endpoint',
                     'meta': {'key1': 'value1', 'key2': 2},
                     'status': 'ready',
                 },
                 'service2': {
                     'name': 'foobar',
-                    'version': '1',
+                    'api_version': '1',
                     'endpoint': '/foobar',
                     'meta': {},
                     'status': 'ready',
                 },
                 'service3': {
                     'name': 'supa-dupa-model',
-                    'version': '1.0',
+                    'api_version': '1.0',
                     'endpoint': '/supa/dupa',
                     'meta': {'key1': 1},
                     'status': 'not ready',
@@ -772,15 +772,15 @@ class TestBaseService(unittest.TestCase):
 
         with self.assertRaisesRegex(exc.PorterError, 'Could not jsonify meta data'):
             with mock.patch('porter.services.cf.json_encoder', spec={'encode.side_effect': TypeError}) as mock_encoder:
-                SC(name='foo', version='bar', meta=object())
-        service_config = SC(name='foo', version='bar', meta=None)
+                SC(name='foo', api_version='bar', meta=object())
+        service_config = SC(name='foo', api_version='bar', meta=None)
         self.assertEqual(service_config.endpoint, '/an/endpoint')
         # make sure this gets set -- shouldn't raise AttributeError
         service_config.id
         # make sure that creating a config with same name and version raises
         # error
         with self.assertRaisesRegex(exc.PorterError, '.*likely means that you tried to instantiate a service.*'):
-            service_config = SC(name='foo', version='bar', meta=None)
+            service_config = SC(name='foo', api_version='bar', meta=None)
 
     @mock.patch('porter.services.BaseService._ids', set())
     @mock.patch('porter.services.api.request_json', lambda: {'foo': 1, 'bar': {'p': 10}})
@@ -795,7 +795,7 @@ class TestBaseService(unittest.TestCase):
                 return 'ready'
 
         with mock.patch('porter.services.BaseService._logger') as mock__logger:
-            service1 = Service(name='name1', version='version1', log_api_calls=True)
+            service1 = Service(name='name1', api_version='version1', log_api_calls=True)
             served = service1()
             mock__logger.info.assert_called_with(
                 'api logging',
@@ -807,7 +807,7 @@ class TestBaseService(unittest.TestCase):
                 )
 
         with mock.patch('porter.services.BaseService._logger') as mock__logger:
-            service2 = Service(name='name2', version='version2', log_api_calls=False)
+            service2 = Service(name='name2', api_version='version2', log_api_calls=False)
             service2()
             mock__logger.assert_not_called()
 
@@ -824,7 +824,7 @@ class TestBaseService(unittest.TestCase):
                 return 'ready'
 
         with mock.patch('porter.services.BaseService._logger') as mock__logger:
-            service1 = Service(name='name1', version='version1', log_api_calls=True)
+            service1 = Service(name='name1', api_version='version1', log_api_calls=True)
             with self.assertRaisesRegex(Exception, 'testing'):
                 service1()
             mock__logger.info.assert_called_with(
@@ -837,7 +837,7 @@ class TestBaseService(unittest.TestCase):
                 )
 
         with mock.patch('porter.services.BaseService._logger') as mock__logger:
-            service2 = Service(name='name2', version='version2', log_api_calls=False)
+            service2 = Service(name='name2', api_version='version2', log_api_calls=False)
             with self.assertRaisesRegex(Exception, 'testing'):
                 service2()
             mock__logger.assert_not_called()
@@ -855,7 +855,7 @@ class TestBaseService(unittest.TestCase):
             def status(self):
                 return 'ready'
 
-        service = Service(name='name', version='version')
+        service = Service(name='name', api_version='version')
         with self.assertRaisesRegex(Exception, 'testing'):
             service()
         mock__logger.exception.assert_called_with(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -472,18 +472,18 @@ class TestMiddlewareService(unittest.TestCase):
     def test_constructor(self):
         middleware_service = MiddlewareService(
             name='a-model',
-            version='1.0',
+            version='v1',
             meta={'foo': 1, 'bar': 'baz'},
             model_endpoint='http://localhost:5000/a-model/prediction',
             max_workers=20
         )
-        expected_id = 'a-model:middleware:1.0'
-        expected_endpoint = '/a-model/batchPrediction'
+        expected_id = 'a-model:middleware:v1'
+        expected_endpoint = '/a-model/v1/batchPrediction'
         expected_meta = {'foo': 1, 'bar': 'baz',
                          'model_endpoint': 'http://localhost:5000/a-model/prediction',
                          'max_workers': 20}
         self.assertEqual(middleware_service.name, 'a-model')
-        self.assertEqual(middleware_service.version, '1.0')
+        self.assertEqual(middleware_service.version, 'v1')
         self.assertEqual(middleware_service.id, expected_id)
         self.assertEqual(middleware_service.endpoint, expected_endpoint)
         self.assertEqual(middleware_service.meta, expected_meta)


### PR DESCRIPTION
This PR resolves #2 by adding the model API version to prediction endpoints, e.g.

  `http://domain/model-name/prediction`

becomes

  `http://domain/model-name/api-verison/prediciton`

Note this PR breaks backwards compatibility by renaming the parameter `version` to `api_version` in service classes. This choice was to remove the ambiguity as to whether version referred to the model version (identified by algorithm and/or trained state) or api version (identified by expected input to the RESTful service).

