### PR TITLE
Toggle exception keys

### DIFF
--- a/porter/config.py
+++ b/porter/config.py
@@ -2,7 +2,9 @@ from .utils import AppEncoder
 
 json_encoder = AppEncoder
 
-# configure error responses
+# Configurations for error responses.
+# Including traceback and user data in responses is useful for debugging
+# but not recommended for production apps
 include_message = True
-include_traceback = True
-include_user_data = True
+include_traceback = False
+include_user_data = False

--- a/porter/config.py
+++ b/porter/config.py
@@ -1,3 +1,8 @@
 from .utils import AppEncoder
 
 json_encoder = AppEncoder
+
+# configure error responses
+include_message = True
+include_traceback = True
+include_user_data = True

--- a/porter/config.py
+++ b/porter/config.py
@@ -5,6 +5,6 @@ json_encoder = AppEncoder
 # Configurations for error responses.
 # Including traceback and user data in responses is useful for debugging
 # but not recommended for production apps
-include_message = True
-include_traceback = False
-include_user_data = False
+return_message_on_error = True
+return_traceback_on_error = False
+return_user_data_on_error = False

--- a/porter/services.py
+++ b/porter/services.py
@@ -732,14 +732,35 @@ class ModelApp:
     models.
 
     Essentially this class is a wrapper around an instance of `flask.Flask`.
-    """
 
-    def __init__(self, json_encoder=None, include_message=None,
-                 include_traceback=None, include_user_data=None):
-        self.include_traceback = cf.include_traceback if include_traceback is None else include_traceback
-        self.include_message = cf.include_message if include_message is None else include_message
-        self.include_user_data = cf.include_user_data if include_user_data is None else include_user_data
+    Args:
+        json_encoder (json.JSONEncoder subclass): A JSON encoder used to
+            format response data. Several useful implementations can be found
+            in `porter.utils`. Defaults to `porter.config.json_encoder`.
+        return_message_on_error (bool): Whether to include the exception
+            message in response on errors. Defaults to
+            `porter.config.return_message_on_error`.
+        return_traceback_on_error (bool): Whether to return the exception
+            traceback in response on errors. Defaults to
+            `porter.config.return_traceback_on_error`.
+        return_user_data_on_error (bool): Whether to return the user data in
+            response on errors. Defaults to
+            `porter.config.include_user_data_on_error`.
+    """
+    json_encoder = cf.json_encoder
+    return_message_on_error = cf.return_message_on_error
+    return_traceback_on_error = cf.return_traceback_on_error
+    return_user_data_on_error = cf.return_user_data_on_error
+
+    def __init__(self, json_encoder=None, return_message_on_error=None,
+                 return_traceback_on_error=None, return_user_data_on_error=None):
         self.json_encoder = cf.json_encoder if json_encoder is None else json_encoder
+        if return_message_on_error is not None:
+            self.return_message_on_error = return_message_on_error
+        if return_traceback_on_error is not None:
+            self.return_traceback_on_error = return_traceback_on_error
+        if return_user_data_on_error is not None:
+            self.return_user_data_on_error = return_user_data_on_error
         self._services = {}
         self.app = self._build_app()
 
@@ -821,9 +842,9 @@ class ModelApp:
         app.json_encoder = self.json_encoder
         # register error handler for all werkzeug default exceptions
         serve_error_message = ServeErrorMessage(
-            include_message=self.include_message,
-            include_traceback=self.include_traceback,
-            include_user_data=self.include_user_data)
+            include_message=self.return_message_on_error,
+            include_traceback=self.return_traceback_on_error,
+            include_user_data=self.return_user_data_on_error)
         for error in werkzeug.exceptions.default_exceptions:
             app.register_error_handler(error, serve_error_message)
         app.register_error_handler(exc.PredictionError, serve_error_message)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -347,7 +347,9 @@ class TestAppErrorHandling(unittest.TestCase):
         # In this class we actually want to test the applications error handling
         # and thus do not set this attribute.
         # See, http://flask.pocoo.org/docs/0.12/api/#flask.Flask.test_client
-        cls.model_app = ModelApp()
+        cls.model_app = ModelApp(return_message_on_error=True,
+                                 return_traceback_on_error=True,
+                                 return_user_data_on_error=True)
         flask_app = cls.model_app.app
         @flask_app.route('/test-error-handling/', methods=['POST'])
         def test_error():
@@ -462,6 +464,36 @@ class TestAppErrorHandling(unittest.TestCase):
         prediction_service = PredictionService(name='failing-model',
             api_version='B', model=None, meta={'1': 'one', 'two': 2})
         cls.model_app.add_service(prediction_service)
+
+    @mock.patch('porter.services.PredictionService._predict')
+    def test_custom_error_keys(self, mock__predict):
+        with mock.patch.object(self.model_app, 'return_user_data_on_error', False), \
+                mock.patch.object(self.model_app, 'return_traceback_on_error', False):
+            mock__predict.side_effect = Exception('testing a failing model')
+            user_data = {'some test': 'data'}
+            resp = self.app_test_client.post('/failing-model/B/prediction', data=json.dumps(user_data))
+            actual = json.loads(resp.data)
+            expected = {
+                'model_name': 'failing-model',
+                'api_version': 'B',
+                '1': 'one',
+                'two': 2,
+                'error': {
+                    'name': 'PredictionError',
+                    'messages': ['an error occurred during prediction'],
+                    'user_data': user_data,
+                    'traceback': re.compile(r".*testing\sa\sfailing\smodel.*"),
+                }
+            }
+            self.assertEqual(resp.status_code, 500)
+            self.assertEqual(actual['model_name'], expected['model_name'])
+            self.assertEqual(actual['api_version'], expected['api_version'])
+            self.assertEqual(actual['1'], expected['1'])
+            self.assertEqual(actual['two'], expected['two'])
+            self.assertEqual(actual['error']['name'], expected['error']['name'])
+            self.assertEqual(actual['error']['messages'], expected['error']['messages'])
+            self.assertNotIn('user_data', actual['error'])
+            self.assertNotIn('traceback', actual['error'])
 
 
 if __name__ == '__main__':

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -39,7 +39,7 @@ class TestFunctions(unittest.TestCase):
         try:
             raise error
         except Exception:
-            actual = _make_error_payload(error, 'foo')
+            actual = _make_error_payload(error, user_data='foo', include_message=True, include_traceback=True, include_user_data=True)
         expected = {
             'error': {
                 'name': 'Exception',
@@ -62,7 +62,7 @@ class TestFunctions(unittest.TestCase):
         try:
             raise error
         except Exception:
-            actual = _make_error_payload(error, 'foo')
+            actual = _make_error_payload(error, user_data='foo', include_message=True, include_traceback=True, include_user_data=True)
         expected = {
             'model_name': 'M',
             'api_version': 'V',

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -39,7 +39,9 @@ class TestFunctions(unittest.TestCase):
         try:
             raise error
         except Exception:
-            actual = _make_error_payload(error, user_data='foo', include_message=True, include_traceback=True, include_user_data=True)
+            actual = _make_error_payload(error, user_data='foo',
+                include_message=True, include_traceback=True,
+                include_user_data=True)
         expected = {
             'error': {
                 'name': 'Exception',
@@ -62,7 +64,9 @@ class TestFunctions(unittest.TestCase):
         try:
             raise error
         except Exception:
-            actual = _make_error_payload(error, user_data='foo', include_message=True, include_traceback=True, include_user_data=True)
+            actual = _make_error_payload(error, user_data='foo',
+                include_message=True, include_traceback=True,
+                include_user_data=True)
         expected = {
             'model_name': 'M',
             'api_version': 'V',
@@ -81,6 +85,67 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(actual['error']['name'], expected['error']['name'])
         self.assertEqual(actual['error']['messages'], expected['error']['messages'])
         self.assertTrue(re.search(expected['error']['traceback'], actual['error']['traceback']))
+        self.assertEqual(actual['error']['user_data'], expected['error']['user_data'])
+
+    def test__make_error_payload_custom_response_keys_no_user_data(self):
+        error = Exception('foo bar baz')
+        try:
+            raise error
+        except Exception:
+            actual = _make_error_payload(error, user_data='foo',
+                include_message=True, include_traceback=True,
+                include_user_data=False)
+        expected = {
+            'error': {
+                'name': 'Exception',
+                'messages': ('foo bar baz',),
+                'traceback': ('.*'
+                              'line [0-9]*, in test__make_error_payload_custom_response_keys_no_user_data\n'
+                              '    raise error\n'
+                              'Exception: foo bar baz.*')
+            }
+        }
+        self.assertEqual(actual['error']['name'], expected['error']['name'])
+        self.assertEqual(actual['error']['messages'], expected['error']['messages'])
+        self.assertTrue(re.search(expected['error']['traceback'], actual['error']['traceback']))
+        self.assertNotIn('user_data', actual['error'])
+
+    def test__make_error_payload_custom_response_keys_name_only(self):
+        error = Exception('foo bar baz')
+        try:
+            raise error
+        except Exception:
+            actual = _make_error_payload(error, user_data='foo',
+                include_message=False, include_traceback=False,
+                include_user_data=False)
+        expected = {
+            'error': {
+                'name': 'Exception',
+            }
+        }
+        self.assertEqual(actual['error']['name'], expected['error']['name'])
+        self.assertNotIn('messages', actual['error'])
+        self.assertNotIn('traceback', actual['error'])
+        self.assertNotIn('user_data', actual['error'])
+
+    def test__make_error_payload_custom_response_keys_name_and_messages(self):
+        error = Exception('foo bar baz')
+        try:
+            raise error
+        except Exception:
+            actual = _make_error_payload(error, user_data='foo',
+                include_message=True, include_traceback=False,
+                include_user_data=False)
+        expected = {
+            'error': {
+                'name': 'Exception',
+                'messages': ('foo bar baz',),
+            }
+        }
+        self.assertEqual(actual['error']['name'], expected['error']['name'])
+        self.assertEqual(actual['error']['messages'], expected['error']['messages'])
+        self.assertNotIn('traceback', actual['error'])
+        self.assertNotIn('user_data', actual['error'])
 
     def test__is_ready(self):
         app_state = {

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -19,7 +19,10 @@ class TestFuntionsUnit(unittest.TestCase):
         # if the current error does not have an error code make sure
         # the response gets a 500
         error = ValueError('an error message')
-        actual = ServeErrorMessage(include_message=True, include_traceback=True, include_user_data=True)(error)
+        mock_app = mock.Mock(return_message_on_error=True,
+                             return_traceback_on_error=True,
+                             return_user_data_on_error=True)
+        actual = ServeErrorMessage(mock_app)(error)
         actual_status_code = 500
         expected_status_code = 500
         self.assertEqual(actual_status_code, expected_status_code)
@@ -30,7 +33,10 @@ class TestFuntionsUnit(unittest.TestCase):
         # make sure that workzeug error codes get passed on to response
         error = ValueError('an error message')
         error.code = 123
-        actual = ServeErrorMessage(include_message=True, include_traceback=True, include_user_data=True)(error)
+        mock_app = mock.Mock(return_message_on_error=True,
+                             return_traceback_on_error=True,
+                             return_user_data_on_error=True)
+        actual = ServeErrorMessage(mock_app)(error)
         actual_status_code = 123
         expected_status_code = 123
         self.assertEqual(actual_status_code, expected_status_code)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -19,7 +19,7 @@ class TestFuntionsUnit(unittest.TestCase):
         # if the current error does not have an error code make sure
         # the response gets a 500
         error = ValueError('an error message')
-        actual = ServeErrorMessage()(error)
+        actual = ServeErrorMessage(include_message=True, include_traceback=True, include_user_data=True)(error)
         actual_status_code = 500
         expected_status_code = 500
         self.assertEqual(actual_status_code, expected_status_code)
@@ -30,7 +30,7 @@ class TestFuntionsUnit(unittest.TestCase):
         # make sure that workzeug error codes get passed on to response
         error = ValueError('an error message')
         error.code = 123
-        actual = ServeErrorMessage()(error)
+        actual = ServeErrorMessage(include_message=True, include_traceback=True, include_user_data=True)(error)
         actual_status_code = 123
         expected_status_code = 123
         self.assertEqual(actual_status_code, expected_status_code)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,7 +9,7 @@ from porter import constants as cn
 from porter import exceptions as exc
 from porter.services import (BaseService, MiddlewareService, ModelApp,
                              PredictionService, StatefulRoute,
-                             serve_error_message)
+                             ServeErrorMessage)
 
 
 class TestFuntionsUnit(unittest.TestCase):
@@ -19,7 +19,7 @@ class TestFuntionsUnit(unittest.TestCase):
         # if the current error does not have an error code make sure
         # the response gets a 500
         error = ValueError('an error message')
-        actual = serve_error_message(error)
+        actual = ServeErrorMessage()(error)
         actual_status_code = 500
         expected_status_code = 500
         self.assertEqual(actual_status_code, expected_status_code)
@@ -30,7 +30,7 @@ class TestFuntionsUnit(unittest.TestCase):
         # make sure that workzeug error codes get passed on to response
         error = ValueError('an error message')
         error.code = 123
-        actual = serve_error_message(error)
+        actual = ServeErrorMessage()(error)
         actual_status_code = 123
         expected_status_code = 123
         self.assertEqual(actual_status_code, expected_status_code)


### PR DESCRIPTION
This PR resolves #1 by allowing users to customize the keys returned to users during an error by instantiating `ModelApp` instances with the desired configurations, e.g.

```python
model_app = ModelApp(
    return_message_on_error=True/False,
    return_traceback_on_error=True/False,
    return_user_data_on_error=True/False
)
```