### PR TITLE
Service endpoints support namespaces and specifying the action (e.g. predict)

### DIFF
--- a/porter/constants.py
+++ b/porter/constants.py
@@ -1,14 +1,12 @@
 import datetime
 
-
 _MODEL_CONTEXT = 'model_context'
 _PREDICTIONS = 'predictions'
 
 
 LIVENESS_ENDPOINT = '/-/alive'
 READINESS_ENDPOINT = '/-/ready'
-PREDICTION_ENDPOINT_TEMPLATE = '/{model_name}/{api_version}/prediction'
-BATCH_PREDICTION_ENDPOINT_TEMPLATE = '/{model_name}/{api_version}/batchPrediction'
+ENDPOINT_TEMPLATE = '{namespace}/{service_name}/{api_version}/{action}'
 
 
 class BASE_KEYS:

--- a/porter/loading.py
+++ b/porter/loading.py
@@ -50,9 +50,9 @@ def load_pkl(path):
     return model
 
 def load_h5(path):
-    """Load and return an object stored in h5 with `keras`."""
-    import keras
-    model = keras.models.load_model(path)
+    """Load and return an object stored in h5 with `tensorflow`."""
+    import tensorflow as tf
+    model = tf.keras.models.load_model(path)
     return model
 
 def load_s3(path, s3_access_key_id, s3_secret_access_key):

--- a/porter/services.py
+++ b/porter/services.py
@@ -162,9 +162,9 @@ class BaseService(abc.ABC, StatefulRoute):
         log_api_calls (bool): Log request and response and response data.
             Default is False.
         namespace (str): A namespace that the service belongs to.
-        endpoint (str): The endpoint where the service is exposed.
         action (str): `str` describing the action of the service, e.g.
             "prediction". Used to determine the final routed endpoint.
+        endpoint (str): The endpoint where the service is exposed.
     """
     _ids = set()
     _logger = logging.getLogger(__name__)
@@ -344,15 +344,19 @@ class PredictionService(BaseService):
 
     Args:
         name (str): The model name. The final routed endpoint will become
-            "/<namespace>/<name>/<api version>/prediction/".
+            "/<namespace>/<name>/<api version>/<action>/".
         api_version (str): The model API version. The final routed endpoint
-            will become "/<namespace>/<name>/<api version>/prediction/".
+            will become "/<namespace>/<name>/<api version>/<action>/".
         meta (dict): Additional meta data added to the response body. Optional.
         log_api_calls (bool): Log request and response and response data.
             Default is False.
         namespace (str): String identifying a namespace that the service belongs
             to. The final routed endpoint will become
-            "/<namespace>/<name>/<api version>/prediction/". Default is "".
+            "/<namespace>/<name>/<api version>/<action>/". Default is "".
+        action (str): `str` describing the action of the service. Used to
+            determine the final routed endpoint. Defaults to "prediction". The
+            final routed endpoint will become
+            "/<namespace>/<name>/<api version>/<action>/".
         model (object): An object implementing the interface defined by
             `porter.datascience.BaseModel`.
         preprocessor (object or None): An object implementing the interface
@@ -387,6 +391,9 @@ class PredictionService(BaseService):
             to. The final routed endpoint will become
             "/<namespace>/<name>/<api version>/prediction/". Default is "".
         api_version (str): The model API version.
+        action (str): `str` describing the action of the service. Used to
+            determine the final routed endpoint. The final routed endpoint
+            will become "/<namespace>/<name>/<api version>/<action>/".
         endpoint (str): The endpoint where the model predictions are exposed.
             This is computed as "/<name>/<api version>/prediction/".
         model (object): An object implementing the interface defined by

--- a/porter/services.py
+++ b/porter/services.py
@@ -168,8 +168,6 @@ class BaseService(abc.ABC, StatefulRoute):
     """
     _ids = set()
     _logger = logging.getLogger(__name__)
-    _invalid_endpoint_characters = string.punctuation.translate(
-        str.maketrans({'-': '', '.': ''}))
 
     def __init__(self, *, name, api_version, meta=None, log_api_calls=False, namespace=''):
         self.name = name
@@ -215,9 +213,10 @@ class BaseService(abc.ABC, StatefulRoute):
 
     def define_endpoint(self):
         """Return the service endpoint derived from instance attributes."""
-        return cn.ENDPOINT_TEMPLATE.format(
+        endpoint = cn.ENDPOINT_TEMPLATE.format(
             namespace=self.namespace, service_name=self.name,
             api_version=self.api_version, action=self.action)
+        return endpoint
 
     @abc.abstractmethod
     def serve(self):
@@ -296,7 +295,6 @@ class BaseService(abc.ABC, StatefulRoute):
             value = '/' + value
         self._namespace = value
 
-
     @property
     def name(self):
         """The model name. The final routed endpoint is generally derived from
@@ -306,10 +304,6 @@ class BaseService(abc.ABC, StatefulRoute):
 
     @name.setter
     def name(self, value):
-        if any(c in value for c in self._invalid_endpoint_characters):
-            raise exc.PorterError(
-                '`name` cannot contain any of the following characters '
-                f'{", ".join(self._invalid_endpoint_characters)}')
         self._name = value
 
     @property
@@ -321,10 +315,6 @@ class BaseService(abc.ABC, StatefulRoute):
 
     @api_version.setter
     def api_version(self, value):
-        if any(c in value for c in self._invalid_endpoint_characters):
-            raise exc.PorterError(
-                '`api_version` cannot contain any of the following characters '
-                f'{", ".join(self._invalid_endpoint_characters)}')
         self._api_version = value
 
     def get_post_data(self):

--- a/porter/services.py
+++ b/porter/services.py
@@ -181,8 +181,8 @@ class BaseService(abc.ABC, StatefulRoute):
         # instance attributes. If the order of assignment changes here these
         # methods may attempt to access attributes that have not been set yet
         # and fail.
-        self.id = self.define_id()
         self.endpoint = self.define_endpoint()
+        self.id = self.define_id()
         self.meta = self.update_meta(self.meta)
         self.log_api_calls = log_api_calls
 
@@ -250,7 +250,7 @@ class BaseService(abc.ABC, StatefulRoute):
         """Return a unique ID for the service. This is used to set the `id`
         attribute.
         """
-        return f'{self.name}:{self.api_version}'
+        return self.endpoint
 
     def check_meta(self, meta):
         """Raise `ValueError` if `meta` contains invalid values, e.g. `meta`
@@ -295,6 +295,7 @@ class BaseService(abc.ABC, StatefulRoute):
         if value and not value.startswith('/'):
             value = '/' + value
         self._namespace = value
+
 
     @property
     def name(self):

--- a/porter/services.py
+++ b/porter/services.py
@@ -414,7 +414,7 @@ class PredictionService(BaseService):
     action = 'prediction'
 
     def __init__(self, *, model, preprocessor=None, postprocessor=None,
-                 input_features=None, allow_nulls=False,
+                 input_features=None, allow_nulls=False, action=None,
                  batch_prediction=False, additional_checks=None, **kwargs):
         self.model = model
         self.preprocessor = preprocessor
@@ -424,6 +424,7 @@ class PredictionService(BaseService):
         self.batch_prediction = batch_prediction
         if additional_checks is not None and not callable(additional_checks):
             raise exc.PorterError('`additional_checks` must be callable')
+        self.action = action or self.action
         self.additional_checks = additional_checks
         self._validate_input = self.schema.input_columns is not None
         self._preprocess_model_input = self.preprocessor is not None

--- a/porter/services.py
+++ b/porter/services.py
@@ -293,6 +293,8 @@ class BaseService(abc.ABC, StatefulRoute):
     def namespace(self, value):
         if value and not value.startswith('/'):
             value = '/' + value
+        if value and value.endswith('/'):
+            value = value[:-1]
         self._namespace = value
 
     @property

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -60,6 +60,7 @@ class TestAppPredictions(unittest.TestCase):
             model=Model1(),
             name='a-model',
             api_version='v0',
+            action='predict',
             preprocessor=Preprocessor1(),
             postprocessor=Postprocessor1(),
             input_features=input_features1,
@@ -70,6 +71,7 @@ class TestAppPredictions(unittest.TestCase):
             model=Model2(),
             name='anotherModel',
             api_version='v1',
+            namespace='n/s/',
             preprocessor=Preprocessor2(),
             postprocessor=None,
             input_features=input_features2,
@@ -108,9 +110,9 @@ class TestAppPredictions(unittest.TestCase):
             {'id': 5, 'feature1':  3},
         ]
         post_data3 = {'id': 1, 'feature1': 5}
-        actual1 = self.app.post('/a-model/v0/prediction', data=json.dumps(post_data1))
+        actual1 = self.app.post('/a-model/v0/predict', data=json.dumps(post_data1))
         actual1 = json.loads(actual1.data)
-        actual2 = self.app.post('/anotherModel/v1/prediction', data=json.dumps(post_data2))
+        actual2 = self.app.post('/n/s/anotherModel/v1/prediction', data=json.dumps(post_data2))
         actual2 = json.loads(actual2.data)
         actual3 = self.app.post('/model-3/v0.0-alpha/prediction', data=json.dumps(post_data3))
         actual3 = json.loads(actual3.data)
@@ -162,7 +164,7 @@ class TestAppPredictions(unittest.TestCase):
             self.assertCountEqual(actual3[key], expected3[key])
 
     def test_prediction_bad_requests_400(self):
-        actual = self.app.post('/a-model/v0/prediction', data='cannot be parsed')
+        actual = self.app.post('/a-model/v0/predict', data='cannot be parsed')
         self.assertTrue(actual.status_code, 400)
         expectd_data = {
             'request_id': 123,
@@ -193,12 +195,12 @@ class TestAppPredictions(unittest.TestCase):
         post_data6 = [{'id': 1, 'feature1': 1, 'feature2': 1},
                       {'id': 1, 'feature1': 0, 'feature2': 1}]
         actuals = [
-            self.app.post('/a-model/v0/prediction', data=json.dumps(post_data1)),
+            self.app.post('/a-model/v0/predict', data=json.dumps(post_data1)),
             self.app.post('/model-3/v0.0-alpha/prediction', data=json.dumps(post_data2)),
-            self.app.post('/anotherModel/v1/prediction', data=json.dumps(post_data3)),
+            self.app.post('/n/s/anotherModel/v1/prediction', data=json.dumps(post_data3)),
             self.app.post('/model-3/v0.0-alpha/prediction', data=json.dumps(post_data4)),
-            self.app.post('/a-model/v0/prediction', data=json.dumps(post_data5)),
-            self.app.post('/anotherModel/v1/prediction', data=json.dumps(post_data6)),
+            self.app.post('/a-model/v0/predict', data=json.dumps(post_data5)),
+            self.app.post('/n/s/anotherModel/v1/prediction', data=json.dumps(post_data6)),
         ]
         # check status codes
         self.assertTrue(all(actual.status_code == 422 for actual in actuals))
@@ -235,9 +237,9 @@ class TestAppPredictions(unittest.TestCase):
                 self.assertEqual(actual_error_obj['model_context'][key], value)
 
     def test_get_prediction_endpoints(self):
-        resp1 = self.app.get('/a-model/v0/prediction')
+        resp1 = self.app.get('/a-model/v0/predict')
         resp2 = self.app.get('/model-3/v0.0-alpha/prediction')
-        resp3 = self.app.get('/anotherModel/v1/prediction')
+        resp3 = self.app.get('/n/s/anotherModel/v1/prediction')
         self.assertEqual(resp1.status_code, 200)
         self.assertEqual(resp2.status_code, 200)
         self.assertEqual(resp3.status_code, 200)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,11 +9,11 @@ import unittest
 from unittest import mock
 
 import flask
-from porter import exceptions as exc
 from porter import __version__
+from porter import constants as cn
+from porter import exceptions as exc
 from porter.datascience import BaseModel, BasePostProcessor, BasePreProcessor
 from porter.services import ModelApp, PredictionService
-from porter import constants as cn
 
 
 @mock.patch('porter.responses.api.request_id', lambda: 123)
@@ -451,7 +451,7 @@ class TestAppErrorHandling(unittest.TestCase):
             'request_id': 123,
             'error': {
                 'name': 'NotFound',
-                'messages': ['The requested URL was not found on the server.  '
+                'messages': ['The requested URL was not found on the server. '
                              'If you entered the URL manually please check your spelling and '
                              'try again.'],
                 'user_data': None,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,15 +4,12 @@ import tempfile
 import unittest
 from unittest import mock
 
-import keras
 import numpy as np
 import pandas as pd
 import sklearn.preprocessing
-
-from sklearn.externals import joblib
-
+import tensorflow as tf
 from porter.utils import NumpyEncoder
-
+from sklearn.externals import joblib
 
 HERE = os.path.dirname(__file__)
 
@@ -37,9 +34,9 @@ class TestExample(unittest.TestCase):
         cls.X['id'] = range(len(X))
         cls.y = np.random.randint(1, 10, size=10)
         cls.preprocessor = sklearn.preprocessing.StandardScaler().fit(cls.X.drop('id', axis=1))
-        cls.model = keras.models.Sequential([
-            keras.layers.Dense(20, activation='relu', input_shape=(3,)),
-            keras.layers.Dense(1, activation='relu')
+        cls.model = tf.keras.models.Sequential([
+            tf.keras.layers.Dense(20, activation='relu', input_shape=(3,)),
+            tf.keras.layers.Dense(1, activation='relu')
         ])
         cls.model.compile(loss='mean_squared_error', optimizer='sgd')
         cls.model.fit(cls.preprocessor.transform(cls.X.drop('id', axis=1)), cls.y, verbose=0)
@@ -48,7 +45,7 @@ class TestExample(unittest.TestCase):
     def test(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             joblib.dump(self.preprocessor, os.path.join(tmpdirname, 'preprocessor.pkl'))
-            keras.models.save_model(self.model, os.path.join(tmpdirname, 'model.h5'))
+            tf.keras.models.save_model(self.model, os.path.join(tmpdirname, 'model.h5'))
             init_namespace = {'model_directory': tmpdirname}
             namespace = load_example(os.path.join(HERE, '../examples/example.py'), init_namespace)
         test_client = namespace['model_app'].app.test_client()

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -3,13 +3,12 @@ import tempfile
 import unittest
 
 import boto3
-import keras
 import numpy as np
 import sklearn.linear_model
-from sklearn.externals import joblib
-
+import tensorflow as tf
 from porter import loading
 from porter.exceptions import PorterError
+from sklearn.externals import joblib
 
 
 class BaseTestLoading(unittest.TestCase):
@@ -71,9 +70,9 @@ class TestLoadingKeras(BaseTestLoading):
     def setUpClass(cls):
         cls.X = np.random.rand(10, 20)
         cls.y = np.random.randint(1, 10, size=10)
-        cls.model = keras.models.Sequential([
-            keras.layers.Dense(20, input_shape=(20,)),
-            keras.layers.Dense(1)
+        cls.model = tf.keras.models.Sequential([
+            tf.keras.layers.Dense(20, input_shape=(20,)),
+            tf.keras.layers.Dense(1)
         ])
         cls.model.compile(loss='mean_squared_error', optimizer='sgd')
         cls.model.fit(cls.X, cls.y, verbose=0)
@@ -82,7 +81,7 @@ class TestLoadingKeras(BaseTestLoading):
 
     def test_load_h5(self):
         with tempfile.NamedTemporaryFile(suffix='.h5') as tmp:
-            keras.models.save_model(self.model, tmp.name)
+            tf.keras.models.save_model(self.model, tmp.name)
             loaded_model = loading.load_h5(tmp.name)
         actual_predictions = loaded_model.predict(self.X)
         expected_predictions = self.predictions
@@ -90,7 +89,7 @@ class TestLoadingKeras(BaseTestLoading):
 
     def test_load_file_h5(self):
         with tempfile.NamedTemporaryFile(suffix='.h5') as tmp:
-            keras.models.save_model(self.model, tmp.name)
+            tf.keras.models.save_model(self.model, tmp.name)
             loaded_model = loading.load_file(tmp.name)
         actual_predictions = loaded_model.predict(self.X)
         expected_predictions = self.predictions
@@ -100,7 +99,7 @@ class TestLoadingKeras(BaseTestLoading):
         key = 'data-science/porter/tests/sklearn_model.h5'
         s3_path = 's3://%s/%s' % (self.bucket, key)
         with tempfile.NamedTemporaryFile(suffix='.h5') as tmp:
-            keras.models.save_model(self.model, tmp.name)
+            tf.keras.models.save_model(self.model, tmp.name)
             self.write_to_s3(tmp.name, self.bucket, key)
         loaded_model = loading.load_file(s3_path,
                 s3_access_key_id=self.s3_access_key_id,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -540,8 +540,6 @@ class TestBaseService(unittest.TestCase):
     @mock.patch('porter.services.BaseService.action', None)
     def test_api_logging_no_exception(self):
         class Service(BaseService):
-            def define_endpoint(self):
-                return '/foo'
             def serve(self):
                 m = mock.Mock(spec=porter_responses.Response)
                 m.jsonify.side_effect = lambda: {'foo': '1', 'p': {10: '10'}}
@@ -572,8 +570,6 @@ class TestBaseService(unittest.TestCase):
     @mock.patch('porter.services.BaseService.action', None)
     def test_api_logging_exception(self):
         class Service(BaseService):
-            def define_endpoint(self):
-                return '/foo'
             def serve(self):
                 raise Exception('testing')
             def status(self):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -638,16 +638,29 @@ class TestBaseService(unittest.TestCase):
         expected = '/my-service/v11/bar'
         self.assertEqual(service.endpoint, expected)
 
-    @mock.patch('porter.services.BaseService._ids', set())
     @mock.patch('porter.services.BaseService.serve', None)
     @mock.patch('porter.services.BaseService.status', None)
     def test_define_endpoint_with_bad_namespace(self):
         class Service(BaseService):
             action = 'bar'
-        # test without namespace (since it's optional)
-        service = Service(name='my-service', api_version='v11', namespace='ns')
-        expected = '/ns/my-service/v11/bar'
-        self.assertEqual(service.endpoint, expected)
+
+        with mock.patch('porter.services.BaseService._ids', set()):
+            # no /
+            service = Service(name='my-service', api_version='v11', namespace='ns')
+            expected = '/ns/my-service/v11/bar'
+            self.assertEqual(service.endpoint, expected)
+
+        with mock.patch('porter.services.BaseService._ids', set()):
+            # trailing /
+            service = Service(name='my-service', api_version='v11', namespace='n/s/')
+            expected = '/n/s/my-service/v11/bar'
+            self.assertEqual(service.endpoint, expected)
+
+        with mock.patch('porter.services.BaseService._ids', set()):
+            # both /
+            service = Service(name='my-service', api_version='v11', namespace='/n/s/')
+            expected = '/n/s/my-service/v11/bar'
+            self.assertEqual(service.endpoint, expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -4,13 +4,12 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
+import porter.responses as porter_responses
 from porter import __version__
 from porter import constants as cn
 from porter import exceptions as exc
-import porter.responses as porter_responses
-from porter.services import (BaseService, ModelApp,
-                             PredictionService, StatefulRoute,
-                             serve_error_message)
+from porter.services import (BaseService, ModelApp, PredictionService,
+                             StatefulRoute, serve_error_message)
 
 
 class TestFunctionsUnit(unittest.TestCase):
@@ -351,6 +350,9 @@ class TestPredictionService(unittest.TestCase):
         with self.assertRaises(E):
             PredictionService.check_request(X, ['id', 'one', 'two', 'three'], False, additional_checks_fail)
 
+    # def test_define_endpoint(self):
+    #     prediction_service = PredictionService(name='my-model', api_version='v1', namespace='/my/namespace')
+
 
     @mock.patch('porter.services.api')
     @mock.patch('porter.responses.api')
@@ -504,6 +506,7 @@ class TestModelApp(unittest.TestCase):
 class TestBaseService(unittest.TestCase):
     @mock.patch('porter.services.BaseService._ids', set())
     @mock.patch('porter.services.BaseService.define_endpoint')
+    @mock.patch('porter.services.BaseService.action', None)
     def test_constructor(self, mock_define_endpoint):
         # test ABC
         with self.assertRaisesRegex(TypeError, 'abstract methods'):
@@ -534,6 +537,7 @@ class TestBaseService(unittest.TestCase):
     @mock.patch('porter.services.BaseService._ids', set())
     @mock.patch('porter.services.api.request_json', lambda: {'foo': 1, 'bar': {'p': 10}})
     @mock.patch('porter.services.api.request_id', lambda: 123)
+    @mock.patch('porter.services.BaseService.action', None)
     def test_api_logging_no_exception(self):
         class Service(BaseService):
             def define_endpoint(self):
@@ -565,6 +569,7 @@ class TestBaseService(unittest.TestCase):
     @mock.patch('porter.services.BaseService._ids', set())
     @mock.patch('porter.services.api.request_json', lambda: {'foo': 1, 'bar': {'p': 10}})
     @mock.patch('porter.services.api.request_id', lambda: 123)
+    @mock.patch('porter.services.BaseService.action', None)
     def test_api_logging_exception(self):
         class Service(BaseService):
             def define_endpoint(self):
@@ -596,6 +601,7 @@ class TestBaseService(unittest.TestCase):
     @mock.patch('porter.services.BaseService._logger')
     @mock.patch('porter.api.request_id', lambda: 123)
     @mock.patch('porter.services.BaseService._ids', set())
+    @mock.patch('porter.services.BaseService.action', None)
     def test_serve_logging_with_exception(self, mock__logger):
         e = Exception('testing')
         class Service(BaseService):
@@ -614,6 +620,39 @@ class TestBaseService(unittest.TestCase):
             extra={'request_id': 123,
                    'service_class': 'Service',
                    'event': 'exception'})
+
+    @mock.patch('porter.services.BaseService._ids', set())
+    @mock.patch('porter.services.BaseService.serve', None)
+    @mock.patch('porter.services.BaseService.status', None)
+    def test_define_endpoint_with_namespace(self):
+        class Service(BaseService):
+            action = 'foo'
+        service = Service(name='my-service', api_version='v11', namespace='/my/namespace')
+        expected = '/my/namespace/my-service/v11/foo'
+        self.assertEqual(service.endpoint, expected)
+
+    @mock.patch('porter.services.BaseService._ids', set())
+    @mock.patch('porter.services.BaseService.serve', None)
+    @mock.patch('porter.services.BaseService.status', None)
+    def test_define_endpoint_with_namespace(self):
+        class Service(BaseService):
+            action = 'bar'
+        # test without namespace (since it's optional)
+        service = Service(name='my-service', api_version='v11')
+        expected = '/my-service/v11/bar'
+        self.assertEqual(service.endpoint, expected)
+
+    @mock.patch('porter.services.BaseService._ids', set())
+    @mock.patch('porter.services.BaseService.serve', None)
+    @mock.patch('porter.services.BaseService.status', None)
+    def test_define_endpoint_with_bad_namespace(self):
+        class Service(BaseService):
+            action = 'bar'
+        # test without namespace (since it's optional)
+        service = Service(name='my-service', api_version='v11', namespace='ns')
+        expected = '/ns/my-service/v11/bar'
+        self.assertEqual(service.endpoint, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Service endpoints support namespaces and specifying the action (e.g. predict).

For example, previously we had

```python
svc = PredictionService(name='myModel', api_version='v1', ...)
svc.endpoint == "/myModel/v1/prediction"
```

Now we can do

```python
svc = PredictionService(name='myModel', api_version='v1', namespace='my/ns', action='predict')
svc.endpoint == "/my/ns/myModel/v1/predict"
```

This is useful for deploying models into environments that utilize endpoint routing as well as giving the user more flexibility.

Of course we can always completely override the default `porter` endpoint with

```python
class MyService(PredictionService):  # or BaseService
    def define_endpoint(self):
        return '/whatever/I/feel/Like'
```

but this is more verbose and the new changes support reasonable use cases.