### PR TITLE
Basic validation of user input in `WrappedModel` class

### DIFF
--- a/porter/datascience.py
+++ b/porter/datascience.py
@@ -56,6 +56,12 @@ class WrappedModel(BaseModel):
     `BaseModel` interface.
     """
     def __init__(self, model):
+        if not hasattr(model, 'predict'):
+            raise TypeError('.predict() method missing for model:\n{}'
+                            .format(model))
+        elif not callable(model.predict):
+            raise TypeError('model.predict() is not callable for model:\n{}'
+                            .format(model))
         self.model = model
         super(WrappedModel, self).__init__()
 

--- a/porter/datascience.py
+++ b/porter/datascience.py
@@ -54,13 +54,13 @@ class BasePostProcessor(abc.ABC):
 class WrappedModel(BaseModel):
     """A convenience class that exposes a model persisted to disk with the
     `BaseModel` interface.
+
+    Args:
+        model: An object with a scikit-learn-compatible ``.predict()`` method.
     """
     def __init__(self, model):
-        if not hasattr(model, 'predict'):
-            raise TypeError('.predict() method missing for model:\n{}'
-                            .format(model))
-        elif not callable(model.predict):
-            raise TypeError('model.predict() is not callable for model:\n{}'
+        if not hasattr(model, 'predict') or not callable(model.predict):
+            raise TypeError('model must have a .predict() method:\n{}'
                             .format(model))
         self.model = model
         super(WrappedModel, self).__init__()
@@ -78,8 +78,15 @@ class WrappedModel(BaseModel):
 class WrappedTransformer(BasePreProcessor):
     """A convenience class that exposes a transformer persisted to disk with
     the `BasePreProcessor` interface.
+
+    Args:
+        transformer: An object with a scikit-learn-compatible ``.transform()``
+            method.
     """
     def __init__(self, transformer):
+        if not hasattr(transformer, 'transform') or not callable(transformer.transform):
+            raise TypeError('transformer must have a .transform() method:\n{}'
+                            .format(transformer))
         self.transformer = transformer
         super(WrappedTransformer, self).__init__()
 

--- a/tests/test_datascience.py
+++ b/tests/test_datascience.py
@@ -27,6 +27,19 @@ class TestWrappedModel(unittest.TestCase):
     def test_from_file_keras(self):
         pass
 
+    def test_model_validation(self):
+        class A:
+            pass
+        class B:
+            predict = 42
+        class C:
+            def predict(x):
+                return x + 1
+        with self.assertRaises(TypeError):
+            WrappedModel(A())
+        with self.assertRaises(TypeError):
+            WrappedModel(B())
+        WrappedModel(C())
 
 class TestBasePreProcessor(unittest.TestCase):
     def test_abc(self):

--- a/tests/test_datascience.py
+++ b/tests/test_datascience.py
@@ -35,11 +35,13 @@ class TestWrappedModel(unittest.TestCase):
         class C:
             def predict(x):
                 return x + 1
-        with self.assertRaises(TypeError):
+        msg = 'model must have a .predict\(\) method'
+        with self.assertRaisesRegex(TypeError, msg):
             WrappedModel(A())
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, msg):
             WrappedModel(B())
         WrappedModel(C())
+
 
 class TestBasePreProcessor(unittest.TestCase):
     def test_abc(self):
@@ -65,6 +67,20 @@ class TestWrappedTransformer(unittest.TestCase):
         expected = 2
         self.assertEqual(actual, expected)
 
+    def test_transformer_validation(self):
+        class A:
+            pass
+        class B:
+            transform = 42
+        class C:
+            def transform(x):
+                return x + 1
+        msg = 'transformer must have a .transform\(\) method'
+        with self.assertRaisesRegex(TypeError, msg):
+            WrappedTransformer(A())
+        with self.assertRaisesRegex(TypeError, msg):
+            WrappedTransformer(B())
+        WrappedTransformer(C())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Check that `model.predict` exists;
- Check that `model.predict()` is callable;
- Otherwise raise a `TypeError`.

Fixes #19.