### PR TITLE
Address issue #38 test failure

### DIFF
--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -132,7 +132,7 @@ class TestLoadingS3(BaseTestLoading):
                 s3_secret_access_key=self.s3_secret_access_key)
 
     def test_load_file_s3_fail_missing_bucket(self):
-        with self.assertRaisesRegex(Exception, r'An error occurred \(403\)'):
+        with self.assertRaisesRegex(Exception, r'An error occurred \(40[34]\)'):
             loading.load_file('s3://invalid-bucket/this/does/not/exist',
                 s3_access_key_id=self.s3_access_key_id,
                 s3_secret_access_key=self.s3_secret_access_key)


### PR DESCRIPTION
Change `test_load_file_s3_fail_missing_bucket` to pass on either 403 or 404 response from S3.

An alternative option would be to ignore the response code and just assert that 'An error occurred'.

Closes #38.
