### PR TITLE
Add expose_docs to default app_meta

### DIFF
--- a/porter/services.py
+++ b/porter/services.py
@@ -877,6 +877,7 @@ class ModelApp:
             ('name', self.name),
             ('description', self.description),
             ('version', self.version),
+            ('expose_docs', self.expose_docs),
         ]
         if self.expose_docs:
             meta.extend([

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -427,6 +427,7 @@ class TestAppHealthChecks(unittest.TestCase):
             'services': {},
             'app_meta': {
                 'description': '<div></div><div><p>(porter v0.15.1)</p></div>',
+                'expose_docs': False,
                 'name': None,
                 'version': None},
         }
@@ -477,6 +478,7 @@ class TestAppHealthChecks(unittest.TestCase):
             },
             'app_meta': {
                 'description': '<div></div><div><p>(porter v0.15.1)</p></div>',
+                'expose_docs': False,
                 'name': None,
                 'version': None},
         }
@@ -513,6 +515,7 @@ class TestAppHealthChecks(unittest.TestCase):
             'deployed_on': cn.HEALTH_CHECK_VALUES.DEPLOYED_ON,
             'app_meta': {
                 'description': '<div></div><div><p>(porter v0.15.1)</p></div>',
+                'expose_docs': False,
                 'name': None,
                 'version': None},
             'services': {
@@ -568,6 +571,7 @@ class TestAppHealthChecks(unittest.TestCase):
             'deployed_on': cn.HEALTH_CHECK_VALUES.DEPLOYED_ON,
             'app_meta': {
                 'description': '<div></div><div><p>(porter v0.15.1)</p></div>',
+                'expose_docs': False,
                 'name': None,
                 'version': None},
             'services': {


### PR DESCRIPTION
This PR adds expose_docs to the default meta data in `ModelApp._init_meta()`.  This should be the last piece needed to close #33.