### PR TITLE
Stabilize docs ordering

### DIFF
--- a/porter/schemas/openapi.py
+++ b/porter/schemas/openapi.py
@@ -340,18 +340,23 @@ def make_openapi_spec(title, description, version, request_schemas, response_sch
 
 
 def _init_paths(request_schemas, response_schemas, additional_params):
+    # first ensure we have all endpoints covered
     endpoints = (
         set(request_schemas.keys())
         | set(response_schemas.keys())
         | set(additional_params.keys())
     )
+    # then, if additional_params covers every endpoint, use its ordering
+    if endpoints == set(additional_params.keys()):
+        endpoints = additional_params.keys()
+    # set methods for each endpoint
     endpoint_methods = {
         endpoint: (set(request_schemas.get(endpoint, {}).keys())
                  | set(response_schemas.get(endpoint, {}).keys())
                  | set(additional_params.get(endpoint, {}).keys()))
         for endpoint in endpoints
     }
-    paths = {}
+    # lowercase each method for each endpoint
     return {endpoint: {method.lower(): {} for method in methods}
             for endpoint, methods in endpoint_methods.items()}
 


### PR DESCRIPTION
This PR ensures stable ordering of the Swagger API docs.  Now endpoints will be documented in the order in which they are defined.  This is ensured by sorting the docs JSON according to the additional_params dict, which is populated in all calls to `ModelApp._route_endpoint()`.